### PR TITLE
build libspecex as a static library

### DIFF
--- a/src/apps/Makefile
+++ b/src/apps/Makefile
@@ -28,9 +28,9 @@ clean :
 
 
 specex_extract : specex_extract.cc
-	$(CXX) $(CXXFLAGS) $(PLUG_FLAGS) -I../library -I../plugin -o $@ $< ../plugin/harp_plugin_specex.$(PLUG_EXT) ../library/libspecex.$(PLUG_EXT) $(PLUG_LINK) $(LINK)
+	$(CXX) $(CXXFLAGS) $(PLUG_FLAGS) -I../library -I../plugin -o $@ $< ../plugin/harp_plugin_specex.$(PLUG_EXT) ../library/libspecex.a $(PLUG_LINK) $(LINK)
 
 % : %.cc
-	$(CXX) $(CXXFLAGS) -I../library -I../plugin -o $@ $< ../library/libspecex.$(PLUG_EXT) $(LINK)
+	$(CXX) $(CXXFLAGS) -I../library -I../plugin -o $@ $< ../library/libspecex.a $(LINK)
 
 

--- a/src/library/Makefile
+++ b/src/library/Makefile
@@ -52,12 +52,13 @@ specex_stamp.o \
 specex_trace.o \
 specex_vector_utils.o
 
-LIBS = libspecex.$(PLUG_EXT)
+LIBS = libspecex.a
 
 all : $(LIBS)
 
-libspecex.$(PLUG_EXT) : $(OBJS)
-	$(CXX) $(PLUG_LINK) -o $@ $(OBJS)
+libspecex.a : $(OBJS)
+	ar cru $@ $(OBJS)
+	ranlib $@
 
 install : all
 	@mkdir -p "$(SPECEX_PREFIX)/lib"; \

--- a/src/plugin/Makefile
+++ b/src/plugin/Makefile
@@ -19,8 +19,8 @@ clean :
 	@rm -f $(PLUGS) *.o *~
 
 
-harp_plugin_specex.$(PLUG_EXT) : harp_plugin_specex.o ../library/libspecex.$(PLUG_EXT)
-	$(CXX) $(PLUG_FLAGS) $(PLUG_LINK) -o $@ $< ../library/libspecex.$(PLUG_EXT) $(LINK)
+harp_plugin_specex.$(PLUG_EXT) : harp_plugin_specex.o ../library/libspecex.a
+	$(CXX) $(PLUG_FLAGS) $(PLUG_LINK) -o $@ $< ../library/libspecex.a $(LINK)
 
 harp_plugin_specex.o : harp_plugin_specex.cc $(HEADERS)
 	$(CXX) $(CXXFLAGS) $(PLUG_FLAGS) -I../library -o $@ -c $<

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -24,5 +24,5 @@ clean :
 
 
 % : %.cc
-	$(CXX) $(CXXFLAGS) -I../library -o $@ $< ../library/libspecex.$(PLUG_EXT) $(LINK)
+	$(CXX) $(CXXFLAGS) -I../library -o $@ $< ../library/libspecex.a $(LINK)
 


### PR DESCRIPTION
In order to avoid having the harp plugin with shared library dependencies, build libspecex statically and link into the plugin and the apps / tests.  An alternative would be to use libtool to handle the RPATH encoding in the shared library, but that is probably overkill. 
