### PR TITLE
Fix plugin serialization

### DIFF
--- a/src/library/specex_serialization.h
+++ b/src/library/specex_serialization.h
@@ -5,6 +5,8 @@
 
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
 
 #include <specex_psf.h>
 #include <specex_gauss_hermite_psf.h>

--- a/src/plugin/harp_plugin_specex.h
+++ b/src/plugin/harp_plugin_specex.h
@@ -32,7 +32,7 @@ namespace harp {
         ar & BOOST_SERIALIZATION_NVP(rows_);
         ar & BOOST_SERIALIZATION_NVP(cols_);
         ar & BOOST_SERIALIZATION_NVP(interpolation_);
-        //ar & BOOST_SERIALIZATION_NVP(actual_specex_psf);
+        ar & BOOST_SERIALIZATION_NVP(actual_specex_psf);
         ar & BOOST_SERIALIZATION_NVP(bundle_);
         return;
       }


### PR DESCRIPTION
Re-enable serialization of underlying PSF shared_ptr.  I had commented this out earlier for debugging.  Also add binary archive support to plugin serialization (which is now used for MPI communication).
