### PR TITLE
Install the specex data files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ all : ; $(NO_CXX)
 install : all ; $(NO_SPECEX_PREFIX)
 	@ for f in $(SUBDIRS); do $(MAKE) -C $$f install; done
 	@ for f in $(PYSCRIPTS); do cp python/$$f $(SPECEX_PREFIX)/bin; done
-	chmod +x $(SPECEX_PREFIX)/bin/specex*
+	@ cp -a data $(SPECEX_PREFIX)/
+	@ chmod +x $(SPECEX_PREFIX)/bin/specex*
 
 uninstall : ; $(NO_SPECEX_PREFIX)
 	@ for f in $(SUBDIRS); do $(MAKE) -C $$f uninstall; done


### PR DESCRIPTION
This allows the pipeline code which creates the default options file for a production to find the corresponding lamp line data files based on the location of the installed executables.