### PR TITLE
Fix compilation of libspecex on OS X

### DIFF
--- a/src/apps/Makefile
+++ b/src/apps/Makefile
@@ -1,4 +1,6 @@
 
+OS := $(shell uname)
+
 PROGS := $(patsubst %.cc,%,$(wildcard *.cc))
 
 .PHONY : all install uninstall clean
@@ -15,9 +17,20 @@ uninstall :
 clean :
 	- $(RM) -f $(PROGS) *.o *~
 
+ifeq ($(OS), Darwin)
+
+specex_extract : specex_extract.cc
+	@echo "#!/bin/bash" > specex_extract
+	@echo "echo 'specex_extract not supported on OSX'" >> specex_extract
+	@chmod +x specex_extract
+
+else
 
 specex_extract : specex_extract.cc
 	$(CXX) $(CXXFLAGS) $(PLUG_FLAGS) -I../library -I../plugin -o $@ $< ../plugin/harp_plugin_specex.$(PLUG_EXT) ../library/libspecex.a $(PLUG_LINK) $(LINK)
+
+endif
+
 
 % : %.cc ../library/libspecex.a
 	$(CXX) $(CXXFLAGS) -I../library -I../plugin -o $@ $< ../library/libspecex.a $(LINK)

--- a/src/apps/specex_flexure_fit_for_flat.cc
+++ b/src/apps/specex_flexure_fit_for_flat.cc
@@ -28,7 +28,7 @@ namespace popts = boost::program_options;
 #ifndef __USE_GNU
 #define __USE_GNU
 #endif
-#include <fenv.h>
+#include <portable_fenv.h>
 
 specex::PSF_p psf;
 specex::image_data image,weight;

--- a/src/apps/specex_flexure_fit_for_science.cc
+++ b/src/apps/specex_flexure_fit_for_science.cc
@@ -29,7 +29,7 @@ namespace popts = boost::program_options;
 #ifndef __USE_GNU
 #define __USE_GNU
 #endif
-#include <fenv.h>
+#include <portable_fenv.h>
 
 namespace specex {
   

--- a/src/apps/specex_psf_fit.cc
+++ b/src/apps/specex_psf_fit.cc
@@ -33,7 +33,7 @@ namespace popts = boost::program_options;
 #ifndef __USE_GNU
 #define __USE_GNU
 #endif
-#include <fenv.h>
+#include <portable_fenv.h>
 
 
 

--- a/src/library/Makefile
+++ b/src/library/Makefile
@@ -5,6 +5,15 @@ OBJS := $(patsubst %.cc,%.o,$(wildcard *.cc))
 
 LIBS = libspecex.a libspecex.$(PLUG_EXT)
 
+OS := $(shell uname)
+
+ifeq ($(OS), Darwin)
+  NOUNDEF = -Wl,-undefined,error
+else
+  NOUNDEF = -Wl,--no-undefined
+endif
+
+
 .PHONY : all install uninstall clean
 
 all : $(LIBS)
@@ -14,7 +23,7 @@ libspecex.a : $(OBJS)
 	ranlib $@
 
 libspecex.$(PLUG_EXT) : $(OBJS)
-	$(CXX) -Wl,--no-undefined -fPIC -shared -o $@ $(OBJS) $(LINK)
+	$(CXX) $(NOUNDEF) -fPIC -shared -o $@ $(OBJS) $(LINK)
 
 install : all
 	mkdir -p $(SPECEX_PREFIX)/lib
@@ -28,4 +37,4 @@ clean :
 
 
 %.o : %.cc $(HEADERS)
-	$(CXX) $(CXXFLAGS) -fPIC -o $@ -c $<
+	$(CXX) $(CXXFLAGS) -I. -fPIC -o $@ -c $<

--- a/src/library/portable_fenv.h
+++ b/src/library/portable_fenv.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include_next <fenv.h>
+
+#if defined(__APPLE__) && defined(__MACH__)
+
+// Public domain polyfill for feenableexcept on OS X
+// http://www-personal.umich.edu/~williams/archive/computation/fe-handling-example.c
+
+inline int feenableexcept(unsigned int excepts)
+{
+    static fenv_t fenv;
+    unsigned int new_excepts = excepts & FE_ALL_EXCEPT;
+    // previous masks
+    unsigned int old_excepts;
+
+    if (fegetenv(&fenv)) {
+        return -1;
+    }
+    old_excepts = fenv.__control & FE_ALL_EXCEPT;
+
+    // unmask
+    fenv.__control &= ~new_excepts;
+    fenv.__mxcsr   &= ~(new_excepts << 7);
+
+    return fesetenv(&fenv) ? -1 : old_excepts;
+}
+
+inline int fedisableexcept(unsigned int excepts)
+{
+    static fenv_t fenv;
+    unsigned int new_excepts = excepts & FE_ALL_EXCEPT;
+    // all previous masks
+    unsigned int old_excepts;
+
+    if (fegetenv(&fenv)) {
+        return -1;
+    }
+    old_excepts = fenv.__control & FE_ALL_EXCEPT;
+
+    // mask
+    fenv.__control |= new_excepts;
+    fenv.__mxcsr   |= new_excepts << 7;
+
+    return fesetenv(&fenv) ? -1 : old_excepts;
+}
+
+#endif

--- a/src/library/specex_desi_main.cc
+++ b/src/library/specex_desi_main.cc
@@ -33,7 +33,7 @@ namespace popts = boost::program_options;
 #ifndef __USE_GNU
 #define __USE_GNU
 #endif
-#include <fenv.h>
+#include <portable_fenv.h>
 
 /*
   input format of fits file

--- a/src/plugin/Makefile
+++ b/src/plugin/Makefile
@@ -1,4 +1,6 @@
 
+OS := $(shell uname)
+
 HEADERS = harp_plugin_specex.h
 
 PLUGS = harp_plugin_specex.$(PLUG_EXT)
@@ -17,9 +19,18 @@ uninstall :
 clean :
 	- $(RM) $(PLUGS) *.o *~
 
+ifeq ($(OS), Darwin)
+
+harp_plugin_specex.$(PLUG_EXT) : harp_plugin_specex.o ../library/libspecex.a
+	touch harp_plugin_specex.$(PLUG_EXT)
+
+else
 
 harp_plugin_specex.$(PLUG_EXT) : harp_plugin_specex.o ../library/libspecex.a
 	$(CXX) $(PLUG_FLAGS) $(PLUG_LINK) -o $@ $< ../library/libspecex.a $(LINK)
 
+endif
+
 harp_plugin_specex.o : harp_plugin_specex.cc $(HEADERS)
 	$(CXX) $(CXXFLAGS) $(PLUG_FLAGS) -I../library -o $@ -c $<
+


### PR DESCRIPTION
This adds a portability header that defines functions in fenv.h that are missing on OS X.  It also disables the  building of the harp plugin, which we are not currently using in DESI.  If we need this in the future on OS X, we should change the way that the build system gets variables from harpconfig, and also change the way the plugin is built.

This is a short term fix to allow the conda packaging of specex on OSX.