### PR TITLE
Library build cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ export PLUG_FLAGS := $(shell harpconfig --plugflags)
 export PLUG_LINK := $(shell harpconfig --pluglink)
 export PLUG_EXT := $(shell harpconfig --plugext)
 export LINK := $(shell harpconfig --link)
+export CPPFLAGS := $(shell harpconfig --cppflags)
 #
 # Copy these scripts to the bin directory.
 #

--- a/src/apps/Makefile
+++ b/src/apps/Makefile
@@ -1,6 +1,4 @@
 
-OS := $(shell uname)
-
 PROGS := $(patsubst %.cc,%,$(wildcard *.cc))
 
 .PHONY : all install uninstall clean
@@ -17,20 +15,11 @@ uninstall :
 clean :
 	- $(RM) -f $(PROGS) *.o *~
 
-ifeq ($(OS), Darwin)
 
-specex_extract : specex_extract.cc
-	@echo "#!/bin/bash" > specex_extract
-	@echo "echo 'specex_extract not supported on OSX'" >> specex_extract
-	@chmod +x specex_extract
-
-else
-
-specex_extract : specex_extract.cc
-	$(CXX) $(CXXFLAGS) $(PLUG_FLAGS) -I../library -I../plugin -o $@ $< ../plugin/harp_plugin_specex.$(PLUG_EXT) ../library/libspecex.a $(PLUG_LINK) $(LINK)
-
-endif
+specex_extract : specex_extract.cc ../plugin/harp_plugin_specex_lib.a ../library/libspecex.a
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -I. -I../library -I../plugin -o $@ $< ../plugin/harp_plugin_specex_lib.a ../library/libspecex.a $(LINK)
 
 
 % : %.cc ../library/libspecex.a
-	$(CXX) $(CXXFLAGS) -I../library -I../plugin -o $@ $< ../library/libspecex.a $(LINK)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -I. -I../library -I../plugin -o $@ $< ../library/libspecex.a $(LINK)
+

--- a/src/apps/specex_extract.cc
+++ b/src/apps/specex_extract.cc
@@ -13,6 +13,8 @@
 
 #include <harp_plugin_specex.h>
 
+#include <specex_serialization.h>
+
 
 using namespace std;
 namespace popts = boost::program_options;

--- a/src/library/Makefile
+++ b/src/library/Makefile
@@ -6,7 +6,6 @@ OBJS := $(patsubst %.cc,%.o,$(wildcard *.cc))
 LIBS = libspecex.a libspecex.$(PLUG_EXT)
 
 OS := $(shell uname)
-
 ifeq ($(OS), Darwin)
   NOUNDEF = -Wl,-undefined,error
 else
@@ -23,7 +22,7 @@ libspecex.a : $(OBJS)
 	ranlib $@
 
 libspecex.$(PLUG_EXT) : $(OBJS)
-	$(CXX) $(NOUNDEF) -fPIC -shared -o $@ $(OBJS) $(LINK)
+	$(CXX) $(NOUNDEF) $(PLUG_FLAGS) $(PLUG_LINK) -o $@ $(OBJS) $(LINK)
 
 install : all
 	mkdir -p $(SPECEX_PREFIX)/lib
@@ -38,3 +37,4 @@ clean :
 
 %.o : %.cc $(HEADERS)
 	$(CXX) $(CXXFLAGS) -I. -fPIC -o $@ -c $<
+

--- a/src/library/specex_desi_main.cc
+++ b/src/library/specex_desi_main.cc
@@ -6,12 +6,12 @@
 
 #include <boost/program_options.hpp>
 
-#include <boost/archive/xml_oarchive.hpp>
-
 #include <harp.hpp>
 
 #include <specex_message.h>
-#include <specex_psf.h>
+
+#include <specex_serialization.h>
+
 #include <specex_trace.h>
 #include <specex_spot.h>
 #include <specex_spot_array.h>
@@ -22,7 +22,7 @@
 #include <specex_psf_fitter.h>
 
 #include <specex_psf_io.h>
-#include <specex_serialization.h>
+
 
 using namespace std;
 using namespace specex;
@@ -502,5 +502,7 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
   return EXIT_SUCCESS;
 }
 
+
+#include <specex_serialization_implement.h>
 
 

--- a/src/library/specex_serialization.h
+++ b/src/library/specex_serialization.h
@@ -1,7 +1,8 @@
 #ifndef SPECEX_SERIALIZATION__H
 #define SPECEX_SERIALIZATION__H
 
-// this file needs to be included only before main() 
+// This file includes all archives used for serialization
+// before the includes for the classes that need to be serialized.
 
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
@@ -14,13 +15,5 @@
 #include <specex_hat_hermite_psf.h>
 #include <specex_hat_moffat_psf.h>
 
-
-
-BOOST_CLASS_EXPORT(specex::PSF_Params)
-BOOST_CLASS_EXPORT(specex::PSF)
-BOOST_CLASS_EXPORT(specex::GaussHermitePSF)
-BOOST_CLASS_EXPORT(specex::GaussHermite2PSF)
-BOOST_CLASS_EXPORT(specex::HatHermitePSF)
-BOOST_CLASS_EXPORT(specex::HatMoffatPSF)
 
 #endif

--- a/src/library/specex_serialization_implement.h
+++ b/src/library/specex_serialization_implement.h
@@ -1,0 +1,16 @@
+#ifndef SPECEX_SERIALIZATION_IMPLEMENT__H
+#define SPECEX_SERIALIZATION_IMPLEMENT__H
+
+// This file registers the derived classes that need to be
+// serialized.  This should be put at the end of the source
+// file containing main(), or in the main entry point of
+// the loadable module.
+
+BOOST_CLASS_EXPORT(specex::PSF_Params)
+BOOST_CLASS_EXPORT(specex::PSF)
+BOOST_CLASS_EXPORT(specex::GaussHermitePSF)
+BOOST_CLASS_EXPORT(specex::GaussHermite2PSF)
+BOOST_CLASS_EXPORT(specex::HatHermitePSF)
+BOOST_CLASS_EXPORT(specex::HatMoffatPSF)
+
+#endif

--- a/src/plugin/Makefile
+++ b/src/plugin/Makefile
@@ -4,10 +4,11 @@ OS := $(shell uname)
 HEADERS = harp_plugin_specex.h
 
 PLUGS = harp_plugin_specex.$(PLUG_EXT)
+LIBS = harp_plugin_specex_lib.a
 
 .PHONY : all install uninstall clean
 
-all : $(PLUGS)
+all : $(PLUGS) $(LIBS)
 
 install : all
 	mkdir -p $(SPECEX_PREFIX)/lib
@@ -17,20 +18,19 @@ uninstall :
 	@ for p in $(PLUGS); do $(RM) "$(SPECEX_PREFIX)/lib/$${p}"; done
 
 clean :
-	- $(RM) $(PLUGS) *.o *~
+	- $(RM) $(PLUGS) *.o *~ *.$(PLUG_EXT) *.a
 
-ifeq ($(OS), Darwin)
 
-harp_plugin_specex.$(PLUG_EXT) : harp_plugin_specex.o ../library/libspecex.a
-	touch harp_plugin_specex.$(PLUG_EXT)
+# We build two versions here, one is an internal library used by applications
+# and the other is a loadable module.
 
-else
+harp_plugin_specex.$(PLUG_EXT) : harp_plugin_specex.o harp_plugin_specex_reg.o ../library/libspecex.a
+	$(CXX) $(PLUG_FLAGS) $(PLUG_LINK) -o $@ $< harp_plugin_specex_reg.o ../library/libspecex.a $(LINK)
 
-harp_plugin_specex.$(PLUG_EXT) : harp_plugin_specex.o ../library/libspecex.a
-	$(CXX) $(PLUG_FLAGS) $(PLUG_LINK) -o $@ $< ../library/libspecex.a $(LINK)
+harp_plugin_specex_lib.a : harp_plugin_specex.o
+	ar cr $@ harp_plugin_specex.o
+	ranlib $@
 
-endif
 
-harp_plugin_specex.o : harp_plugin_specex.cc $(HEADERS)
-	$(CXX) $(CXXFLAGS) $(PLUG_FLAGS) -I../library -o $@ -c $<
-
+%.o : %.cc $(HEADERS)
+	$(CXX) $(CXXFLAGS) -I. -I../library -fPIC -o $@ -c $<

--- a/src/plugin/harp_plugin_specex.cc
+++ b/src/plugin/harp_plugin_specex.cc
@@ -241,10 +241,6 @@ size_t harp::specex_psf::response_nnz_estimate ( ) const {
 }
 
 
-// This export statement allows use of the plugin with serialization operations in HARP.
-
-BOOST_CLASS_EXPORT(harp::specex_psf)
-
 // Define the plugin creation function here.
 
 harp::psf * harp::specex_psf_create ( boost::property_tree::ptree const & props ) {

--- a/src/plugin/harp_plugin_specex.h
+++ b/src/plugin/harp_plugin_specex.h
@@ -5,9 +5,9 @@
 
 #include <harp.hpp>
 
-#include <specex_psf.h>
-#include <specex_psf_io.h>
 #include <specex_serialization.h>
+
+#include <specex_psf_io.h>
 
 #include <iostream>
 

--- a/src/plugin/harp_plugin_specex_reg.cc
+++ b/src/plugin/harp_plugin_specex_reg.cc
@@ -1,0 +1,9 @@
+
+#include <harp_plugin_specex.h>
+
+#include <specex_serialization_implement.h>
+
+// This export statement allows use of the plugin with 
+// serialization operations in HARP.
+BOOST_CLASS_EXPORT(harp::specex_psf)
+


### PR DESCRIPTION
These changes separate the building of internal libraries from the building of loadable modules.  Due to a happy coincidence, the old way worked on Linux for our use cases, but these changes do this in a more correct way.  Slight changes to the includes for serialization registration were needed.