### PR TITLE
Version function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,15 @@
 .waf*
 build*
 
+# compiled files
+src/apps/*
+!src/apps/*.cc
+!src/apps/Makefile
+!src/apps/wscript
+src/tests/*
+!src/tests/*.cc
+!src/tests/Makefile
+!src/tests/wscript
+
 # MacOS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ PYSCRIPTS = specex_mean_psf.py
 #
 # This is a message to make that these targets are 'actions' not files.
 #
-.PHONY : all clean install uninstall
+.PHONY : all clean install uninstall version
 #
 # This should compile all code prior to it being installed.
 #
@@ -73,3 +73,9 @@ uninstall : ; $(NO_SPECEX_PREFIX)
 clean :
 	- $(RM) *~ core
 	@ for f in $(SUBDIRS); do $(MAKE) -C $$f clean ; done
+#
+# Enable 'make version' to update the version string.
+# Do make TAG=0.1.2 version to set the tag explicitly.
+#
+version :
+	$(MAKE) -C src version

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 
 DIRS = library plugin tests apps
 
-.PHONY : all install clean uninstall $(DIRS)
+.PHONY : all install clean uninstall version $(DIRS)
 
 all : $(DIRS)
 
@@ -25,3 +25,6 @@ uninstall :
 
 clean :
 	@ for d in $(DIRS); do $(MAKE) -C $$d clean; done
+
+version :
+	$(MAKE) -C library version

--- a/src/apps/specex_version.cc
+++ b/src/apps/specex_version.cc
@@ -1,0 +1,11 @@
+#include <iostream>
+
+#include <specex_version.h>
+
+using namespace std;
+using namespace specex;
+
+int main ( int argc, char *argv[] ) {
+  cout << version() << endl;
+  return 0
+}

--- a/src/apps/specex_version.cc
+++ b/src/apps/specex_version.cc
@@ -7,5 +7,5 @@ using namespace specex;
 
 int main ( int argc, char *argv[] ) {
   cout << version() << endl;
-  return 0
+  return 0;
 }

--- a/src/library/Makefile
+++ b/src/library/Makefile
@@ -13,7 +13,7 @@ else
 endif
 
 
-.PHONY : all install uninstall clean
+.PHONY : all install uninstall clean version
 
 all : $(LIBS)
 
@@ -34,6 +34,16 @@ uninstall :
 clean :
 	- $(RM) $(LIBS) *.o *~
 
+#
+# Enable 'make version' to update the version string.
+# Do make TAG=0.1.2 version to set the tag explicitly.
+#
+LASTTAG := $(shell git describe --tags --dirty --always | cut -d- -f1)
+COUNT := $(shell git rev-list --count HEAD)
+version :
+	- $(RM) version.h
+	@ if test -n "$(TAG)"; then v=$(TAG); else v=$(LASTTAG).dev$(COUNT); fi; \
+		echo "#define VERSION_STRING \"$$v\"" > version.h
 
 %.o : %.cc $(HEADERS)
 	$(CXX) $(CXXFLAGS) -I. -fPIC -o $@ -c $<

--- a/src/library/specex_version.cc
+++ b/src/library/specex_version.cc
@@ -1,0 +1,9 @@
+#include "specex_version.h"
+
+using namespace std;
+
+string specex::version(void)
+{
+    string theVersion(VERSION_STRING);
+    return theVersion;
+}

--- a/src/library/specex_version.h
+++ b/src/library/specex_version.h
@@ -1,0 +1,10 @@
+#ifndef SPECEX_VERSION__H
+#define SPECEX_VERSION__H
+
+#include "version.h"
+
+namespace specex {
+    std::string version(void);
+};
+
+#endif

--- a/src/library/specex_version.h
+++ b/src/library/specex_version.h
@@ -1,6 +1,7 @@
 #ifndef SPECEX_VERSION__H
 #define SPECEX_VERSION__H
 
+#include <string>
 #include "version.h"
 
 namespace specex {

--- a/src/library/version.h
+++ b/src/library/version.h
@@ -1,0 +1,1 @@
+#define VERSION_STRING "0.5.0.dev515"


### PR DESCRIPTION
This PR fixes #12 by adding a library function that returns a version string.

* The function call is `specex::version()`.
* An executable, `specex_version` will be generated on install.  All this does is print the version string to `std::cout`.
* For development, `make version` will update the version string.
* When a new tag is ready `make TAG=x.y.z` will set the version string to the desired name.