### PR TITLE
Only get git info when needed

### DIFF
--- a/src/library/Makefile
+++ b/src/library/Makefile
@@ -37,11 +37,13 @@ clean :
 #
 # Enable 'make version' to update the version string.
 # Do make TAG=0.1.2 version to set the tag explicitly.
+# LASTTAG and COUNT are defined inside the recipe so they
+# only get defined when make version is invoked.
 #
-version : LASTTAG := $(shell git describe --tags --dirty --always | cut -d- -f1)
-version : COUNT := $(shell git rev-list --count HEAD)
 version :
 	- $(RM) version.h
+	$(eval LASTTAG := $$(shell git describe --tags --dirty --always | cut -d- -f1))
+	$(eval COUNT := $$(shell git rev-list --count HEAD))
 	@ if test -n "$(TAG)"; then v=$(TAG); else v=$(LASTTAG).dev$(COUNT); fi; \
 		echo "#define VERSION_STRING \"$$v\"" > version.h
 

--- a/src/library/Makefile
+++ b/src/library/Makefile
@@ -38,8 +38,8 @@ clean :
 # Enable 'make version' to update the version string.
 # Do make TAG=0.1.2 version to set the tag explicitly.
 #
-LASTTAG := $(shell git describe --tags --dirty --always | cut -d- -f1)
-COUNT := $(shell git rev-list --count HEAD)
+version : LASTTAG := $(shell git describe --tags --dirty --always | cut -d- -f1)
+version : COUNT := $(shell git rev-list --count HEAD)
 version :
 	- $(RM) version.h
 	@ if test -n "$(TAG)"; then v=$(TAG); else v=$(LASTTAG).dev$(COUNT); fi; \
@@ -47,4 +47,3 @@ version :
 
 %.o : %.cc $(HEADERS)
 	$(CXX) $(CXXFLAGS) -I. -fPIC -o $@ -c $<
-

--- a/src/library/version.h
+++ b/src/library/version.h
@@ -1,1 +1,1 @@
-#define VERSION_STRING "0.6.1.dev528"
+#define VERSION_STRING "0.6.1.dev529"

--- a/src/library/version.h
+++ b/src/library/version.h
@@ -1,1 +1,1 @@
-#define VERSION_STRING "0.6.1.dev527"
+#define VERSION_STRING "0.6.1.dev528"


### PR DESCRIPTION
This PR fixes desihub/desiutil#107 by only obtaining git metadata when it is actually needed (and when presumably one is actually inside a git clone).