### PR TITLE
Merge exception

### DIFF
--- a/src/library/specex_desi_main.cc
+++ b/src/library/specex_desi_main.cc
@@ -574,6 +574,8 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
     return EXIT_FAILURE;
  }
   
+  // may prevent crashing on non-floating point exceptions outside this function
+  fedisableexcept (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW);
   return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
This PR fixes #32 by adding the line:
```
fedisableexcept (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW);
```
before 
```
return EXIT_SUCCESS; 
```
in [`specex_desi_main.cc`](https://github.com/desihub/specex/blob/master/src/library/specex_desi_main.cc). This allows floating point exceptions to halt execution, as originally intended, while not causing the crash during python execution of [`specex.py`](https://github.com/desihub/desispec/blob/master/py/desispec/scripts/specex.py). 