### PR TITLE
Timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 0.6.8 (unreleased)
 
-* No changes yet
+* Added timeout option
 
 ## 0.6.7 (2020-04-15)
 

--- a/src/library/specex_desi_main.cc
+++ b/src/library/specex_desi_main.cc
@@ -75,12 +75,13 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
   // read arguments to look for timing option
   int timeout=0;
   for(int i=1;i<argc;i++) {
-    if(string(argv[i]).find("timeout") != std::string::npos) {
-      if(i==(argc-1)) {
-	throw std::runtime_error("error, need a value in seconds after argument timeout");
-      }
-      timeout=atoi(argv[i+1]);
-      break;
+    //if(string(argv[i]).find("timeout") != std::string::npos) {
+    if(strstr(argv[i],"timeout")) {
+	if(i==(argc-1)) {
+	  throw std::runtime_error("error, need a value in seconds after argument timeout");
+	}
+	timeout=atoi(argv[i+1]);
+	break;
     }
   }
 

--- a/src/library/specex_desi_main.cc
+++ b/src/library/specex_desi_main.cc
@@ -4,6 +4,10 @@
 #include <string>
 #include <map>
 
+#include <future>
+#include <functional>
+#include <unistd.h>
+
 #include <boost/program_options.hpp>
 
 #include <harp.hpp>
@@ -62,11 +66,55 @@ std::vector<std::string> split(const std::string& s, char delimiter) {
   return tokens;
 }
 
+
+int specex_desi_psf_fit_main_without_timeout ( int argc, char *argv[] );
+
 int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
-  
+
+
+  // read arguments to look for timing option
+  int timeout=0;
+  for(int i=1;i<argc;i++) {
+    if(string(argv[i]).find("timeout") != std::string::npos) {
+      if(i==(argc-1)) {
+	throw std::runtime_error("error, need a value in seconds after argument timeout");
+      }
+      timeout=atoi(argv[i+1]);
+      break;
+    }
+  }
+
+  if (timeout>0) {
+    cout << "Will consider a timeout of " << timeout << " seconds" << endl;
+
+    std::packaged_task<int()> task(std::bind(specex_desi_psf_fit_main_without_timeout,argc,argv));
+    auto future = task.get_future();
+    std::thread thr(std::move(task));
+    if (future.wait_for(std::chrono::seconds(timeout)) != std::future_status::timeout)
+      {
+	thr.join();
+	future.get(); // this will propagate exception from f() if any
+      }
+    else
+      {
+	thr.detach(); // we leave the thread still running
+	cout << "ERROR timeout, fit exceeds " << timeout << " seconds" << endl;
+	throw std::runtime_error("Timeout");
+      }
+  } else {
+    specex_desi_psf_fit_main_without_timeout(argc,argv);
+  }
+  return 0;
+}
+
+
+
+
+int specex_desi_psf_fit_main_without_timeout ( int argc, char *argv[] ) {
+
   // to crash when NaN
   feenableexcept (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW);
-  
+
   // -------------------------------------------------------
   string arc_image_filename="";
   string input_psf_filename="";
@@ -79,32 +127,33 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
   int header_hdu=0;
   int xtrace_hdu=0;
   int ytrace_hdu=0;
-  
+
   string psf_model="";
   int    first_fiber_bundle=0;
   int    last_fiber_bundle=0;
   int    first_fiber=0;
   int    last_fiber=0;
   int    half_size_x=0;
-  int    half_size_y=0;  
+  int    half_size_y=0;
   int gauss_hermite_deg=0;
-  int gauss_hermite_deg2=0; 
+  int gauss_hermite_deg2=0;
   int legendre_deg_wave=0;
   int legendre_deg_x=0;
   int trace_deg_wave=0;
-  int trace_deg_x=0;  
+  int trace_deg_x=0;
   int trace_prior_deg=0;
   double psf_error=0;
   double psf_core_wscale=0;
-  int max_number_of_lines=0; 
+  int max_number_of_lines=0;
 
+  int timeout=0;
   string broken_fibers_string="";
-  
-  
+
+
   string lamp_lines_filename="";
   if(getenv("SPECEXDATA"))
     lamp_lines_filename = string(getenv("SPECEXDATA"))+"/specex_linelist_desi.txt";
-   
+
   // reading arguments
   // --------------------------------------------
   popts::options_description desc ( "Allowed Options" );
@@ -114,8 +163,8 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
   desc.add_options()
     ( "help,h", "display usage information" )
     ( "arc,a", popts::value<string>( &arc_image_filename ), "arc preprocessed fits image file name (mandatory)" )
-    ( "in-psf", popts::value<string>( &input_psf_filename ), " input psf file name (fits or xml, can contain only the traces, mandatory)")  
-    ( "out-psf", popts::value<string>( &output_fits_filename ), " output psf fits file name (mandatory)")  
+    ( "in-psf", popts::value<string>( &input_psf_filename ), " input psf file name (fits or xml, can contain only the traces, mandatory)")
+    ( "out-psf", popts::value<string>( &output_fits_filename ), " output psf fits file name (mandatory)")
     ( "only-trace-fit", "only fit the trace coordinates (default is trace,sigma,psf)")
     ( "no-trace-fit", "do not fit the trace coordinates (default is trace,sigma,psf)")
     ( "no-sigma-fit", "do not fit the gaussian sigma (default is trace,sigma,psf)")
@@ -126,7 +175,7 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
     ( "header-hdu", popts::value<int>( &header_hdu )->default_value(1), " header hdu in input arc fits, for unusual data format")
 
     // ( "trace", popts::value<string>( &trace_filename ), "fits image file name with image extensions XTRACE and YTRACE for legendre polynomial of wavelength (mandatory)" )
-    
+
     ( "xcoord-hdu", popts::value<int>( &xtrace_hdu )->default_value(-1), "hdu of x trace legendre polynomial of wavelength (default is extension XTRACE)" )
     ( "ycoord-hdu", popts::value<int>( &ytrace_hdu )->default_value(-1), "hdu of y trace legendre polynomial of wavelength (default is extension YTRACE)" )
     ( "first-bundle", popts::value<int>( &first_fiber_bundle )->default_value(0), "first fiber bundle to fit")
@@ -154,7 +203,7 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
     ( "psf-error",  popts::value<double>( &psf_error )->default_value(0), "psf fractional uncertainty (default is 0.01, for weights in the fit)")
     ( "psf-core-wscale",  popts::value<double>( &psf_core_wscale ), "scale up the weight of pixels in 5x5 PSF core")
     ( "broken-fibers", popts::value<string>( &broken_fibers_string ), "broken fibers (comma separated list)")
-    
+
 #ifdef EXTERNAL_TAIL
     ( "fit-psf-tails", "unable fit of psf tails")
 #endif
@@ -162,19 +211,21 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
     ( "fit-continuum", "unable fit of continuum")
 #endif
     ( "variance-model", "refit at the end with a model of the variance to avoid Poisson noise bias")
-    
+
     ( "out-psf-xml", popts::value<string>( &output_xml_filename ), " output psf xml file name")
-   
-    ( "out-spots", popts::value<string>( &output_spots_filename ), " output spots file name")  
-    ( "prior", popts::value< vector<string> >( &argurment_priors )->multitoken(), " gaussian prior on a param : 'name' value error")  
-    ( "tmp_results", " write tmp results")  
-    ( "nlines", popts::value<int>( &max_number_of_lines )->default_value(200)," maximum number of emission lines used in fit (uses a algorithm to select best ones based on S/N and line coverage")  
+
+    ( "out-spots", popts::value<string>( &output_spots_filename ), " output spots file name")
+    ( "prior", popts::value< vector<string> >( &argurment_priors )->multitoken(), " gaussian prior on a param : 'name' value error")
+    ( "tmp_results", " write tmp results")
+    ( "nlines", popts::value<int>( &max_number_of_lines )->default_value(200)," maximum number of emission lines used in fit (uses a algorithm to select best ones based on S/N and line coverage")
     //( "out", popts::value<string>( &outfile ), "output image file" )
+    ( "timeout", popts::value<int>( &timeout )->default_value(0) , "timeout value in seconds, throws exception is fit not finished before.")
+
     ;
 
   popts::variables_map vm;
 
-  try {    
+  try {
     popts::store(popts::command_line_parser( argc, argv ).options(desc).run(), vm);
     popts::notify(vm);
   }catch(std::exception& e) {
@@ -182,38 +233,38 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
     cerr << "try --help for options" << endl;
     return EXIT_FAILURE;
   }
-  
+
   if ( ( argc < 2 ) || vm.count( "help" ) ) {
       cerr << endl;
-      cerr << desc << endl;      
+      cerr << desc << endl;
       return EXIT_FAILURE;
   }
   if ( ! vm.count( "arc" ) ) {
     cerr << endl;
-    cerr << "missing --arc , try --help for options" << endl;      
+    cerr << "missing --arc , try --help for options" << endl;
     return EXIT_FAILURE;
   }
   if ( ! vm.count( "in-psf" ) ) {
     cerr << endl;
-    cerr << "missing --in-psf , try --help for options" << endl;      
+    cerr << "missing --in-psf , try --help for options" << endl;
     return EXIT_FAILURE;
-  }    
+  }
   if(lamp_lines_filename == "") {
     cerr << endl;
     cerr << "missing lamp_lines_filename either define env. variable SPECEXDATA or use option --lamplines" << endl;
     return EXIT_FAILURE;
   }
-  
+
   // set logging info
   specex_set_debug(vm.count("debug")>0);
   specex_set_verbose(vm.count("quiet")==0);
-  
+
   // check input PSF type, can be from boot calib with only the traces
   bool use_input_specex_psf = false;
   if (input_psf_filename.find(".xml") != std::string::npos) { // xml file
     SPECEX_INFO("Input PSF file is xml");
     use_input_specex_psf = true;
-  }else{ // fits file, look at header  
+  }else{ // fits file, look at header
     try {
       fitsfile * fp;
       harp::fits::open_read(fp,input_psf_filename);
@@ -222,14 +273,14 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
       fits_movabs_hdu ( fp, first_hdu, NULL, &status ); harp::fits::check ( status );
       string psftype; harp::fits::key_read(fp,"PSFTYPE",psftype);
       SPECEX_INFO("Input PSF type = " << psftype);
-      use_input_specex_psf = (psftype=="GAUSS-HERMITE"); 
+      use_input_specex_psf = (psftype=="GAUSS-HERMITE");
     } catch (harp::exception) {
       SPECEX_WARNING("Could not read PSF type in " << input_psf_filename);
     }
   }
 
-  // if PSF parameter options are given, we cannot start from a pre-existing specex psf  
-  bool psf_change_req = false; 
+  // if PSF parameter options are given, we cannot start from a pre-existing specex psf
+  bool psf_change_req = false;
   psf_change_req |= (! vm["half-size-x"].defaulted());
   psf_change_req |= (! vm["half-size-y"].defaulted());
   psf_change_req |= (! vm["gauss-hermite-deg"].defaulted());
@@ -238,7 +289,7 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
   psf_change_req |= (! vm["legendre-deg-x"].defaulted());
   psf_change_req |= (! vm["trace-deg-wave"].defaulted());
   psf_change_req |= (! vm["trace-deg-x"].defaulted());
-  
+
   if(psf_change_req && use_input_specex_psf) {
     SPECEX_WARNING("option(s) were given to specify the psf properties, so we cannot use the input PSF parameters as a starting point (except for the trace coordinates)");
     use_input_specex_psf = false;
@@ -248,7 +299,7 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
   }
 
 
-  
+
   vector<string> tokens = split(broken_fibers_string,',');
   vector<int> broken_fibers;
   for(size_t i=0;i<tokens.size();i++) {
@@ -258,7 +309,7 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
   for(size_t i=0;i<broken_fibers.size();i++) {
    SPECEX_DEBUG("input broken fiber #" << broken_fibers[i]);
   }
-  
+
   // dealing with priors
   map<string,Prior*> priors;
   {
@@ -281,14 +332,14 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
       cerr << "priors must be of the form 'name value error'" << endl;
       cerr << desc << endl;
       return EXIT_FAILURE;
-    } 
+    }
   }
-  
+
 
 
   try {
-   
-    
+
+
     specex_set_dump_core(vm.count("core")>0);
     bool fit_traces = (vm.count("no-trace-fit")==0);
     bool fit_sigmas = (vm.count("no-sigma-fit")==0);
@@ -300,15 +351,15 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
       }
       fit_traces = true;
       fit_sigmas = false;
-      fit_psf    = false;      
+      fit_psf    = false;
     }
-    
+
     bool single_bundle = (vm.count("single-bundle")>0);
 
     bool write_tmp_results = (vm.count("tmp-results")>0);
-        
+
     if(trace_prior_deg>0) SPECEX_INFO("Will apply a prior on the traces high order terms in a bundle");
-    
+
 
 #ifdef EXTERNAL_TAIL
     bool fit_psf_tails = (vm.count("fit-psf-tails")>0);
@@ -318,18 +369,18 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
 #endif
     bool use_variance_model = (vm.count("variance-model")>0);
     bool fit_individual_spots_position = vm.count("positions");
-    
-    SPECEX_INFO("using lamp lines file " << lamp_lines_filename); 
-    
+
+    SPECEX_INFO("using lamp lines file " << lamp_lines_filename);
+
     // read data
     map<string,string> header;
     image_data image,weight,mask,rdnoise;
     read_DESI_preprocessed_image(arc_image_filename,image,weight,mask,rdnoise,header);
-        
+
     // read PSF
-    specex::PSF_p psf;    
+    specex::PSF_p psf;
     if( ! use_input_specex_psf ) {
-      SPECEX_INFO("Initializing a " << psf_model << " PSF");      
+      SPECEX_INFO("Initializing a " << psf_model << " PSF");
       if(psf_model=="GAUSSHERMITE")
 	psf = PSF_p(new specex::GaussHermitePSF(gauss_hermite_deg));
       else if(psf_model=="GAUSSHERMITE2")
@@ -342,12 +393,12 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
 	psf = PSF_p(new specex::DiskMoffatPSF(gauss_hermite_deg));
       else
 	SPECEX_ERROR("don't know this psf model");
-      
+
       psf->hSizeX = half_size_x;
       psf->hSizeY = half_size_y;
       SPECEX_INFO("trace_deg_x=" << trace_deg_x << " trace_deg_wave=" << trace_deg_wave);
-      read_traceset_fits(psf,input_psf_filename,trace_deg_x,trace_deg_wave);     
-      
+      read_traceset_fits(psf,input_psf_filename,trace_deg_x,trace_deg_wave);
+
     }else{ // use_input_specex_psf
       read_psf(psf,input_psf_filename);
     }
@@ -357,11 +408,11 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
       psf->FiberTraces[broken_fibers[i]].mask = 3;
       SPECEX_DEBUG("Fiber trace " << broken_fibers[i] << " OFF=" << psf->FiberTraces[broken_fibers[i]].Off());
     }
-    
-    
+
+
     psf->ccd_image_n_cols = image.n_cols();
     psf->ccd_image_n_rows = image.n_rows();
-      
+
     // bundle sizes
     int number_of_fibers_per_bundle=0;
     if(single_bundle) {
@@ -369,27 +420,27 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
     }else {
       number_of_fibers_per_bundle = eval_bundle_size(psf->FiberTraces);
     }
-    int number_of_fiber_bundles_per_ccd=psf->FiberTraces.size()/number_of_fibers_per_bundle;          
+    int number_of_fiber_bundles_per_ccd=psf->FiberTraces.size()/number_of_fibers_per_bundle;
     if(first_fiber_bundle<0 || first_fiber_bundle>= number_of_fiber_bundles_per_ccd) {
       SPECEX_ERROR("invalid first fiber bundle");
     }
     if(last_fiber_bundle<first_fiber_bundle || last_fiber_bundle>= number_of_fiber_bundles_per_ccd) {
       SPECEX_ERROR("invalid last fiber bundle");
     }
-    
 
-    
+
+
     // init PSF fitter
-    // -------------------------------------------- 
+    // --------------------------------------------
     PSF_Fitter fitter(psf,image,weight,rdnoise);
-    
+
     fitter.polynomial_degree_along_x    = legendre_deg_x;
     fitter.polynomial_degree_along_wave = legendre_deg_wave;
     fitter.psf->psf_error               = psf_error;
     fitter.corefootprint_weight_boost   = psf_core_wscale;
     fitter.write_tmp_results            = write_tmp_results;
     fitter.trace_prior_deg              = trace_prior_deg;
-    
+
 #ifdef EXTERNAL_TAIL
     fitter.scheduled_fit_of_psf_tail    = fit_psf_tails;
 #endif
@@ -399,43 +450,43 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
 #endif
 
     fitter.scheduled_fit_with_weight_model  = use_variance_model;
-    
+
     fitter.scheduled_fit_of_traces      = fit_traces;
     fitter.scheduled_fit_of_sigmas      = fit_sigmas;
     fitter.scheduled_fit_of_psf         = fit_psf;
     fitter.direct_simultaneous_fit      = true; // use_input_specex_psf;
     fitter.max_number_of_lines          = max_number_of_lines;
-    
+
     fitter.psf->gain = 1; // images are already in electrons
     fitter.psf->readout_noise = 0; // readnoise is a property of image, not PSF
-        
+
     if(header.find("CAMERA") != header.end()) {
       fitter.psf->camera_id = header["CAMERA"];
       SPECEX_INFO("CAMERA = " << fitter.psf->camera_id );
     }else{
       SPECEX_WARNING("CAMERA Id not found in header");
     }
-    
+
     fitter.priors = priors;
-    
-    
+
+
     fitter.mask.Clear();
 
-    
+
     SPECEX_INFO(
-		"PSF '" << psf_model << "' stamp size = " 
+		"PSF '" << psf_model << "' stamp size = "
 		<< psf->hSizeX << "x" << psf->hSizeY );
-    
-    
-    
+
+
+
     int first_fitted_fiber=-1;
     int last_fitted_fiber=-1;
     vector<Spot_p> fitted_spots;
-    
-    // loop on fiber bundles 
-    // -------------------------------------------- 
+
+    // loop on fiber bundles
+    // --------------------------------------------
     for(int bundle = first_fiber_bundle; bundle <= last_fiber_bundle ; bundle ++) {
-    
+
       // allocate bundle in PSF if necessary
       if(psf->ParamsOfBundles.find(bundle)==psf->ParamsOfBundles.end()) {
 	psf->ParamsOfBundles[bundle] = specex::PSF_Params();
@@ -443,7 +494,7 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
 	psf->ParamsOfBundles[bundle].fiber_min = number_of_fibers_per_bundle*bundle;
 	psf->ParamsOfBundles[bundle].fiber_max = psf->ParamsOfBundles[bundle].fiber_min+number_of_fibers_per_bundle-1; // included
       }
-      
+
 
       // now check mask ?
       if(psf->ParamsOfBundles[bundle].fiber_min < first_fiber) {
@@ -454,22 +505,22 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
 	psf->ParamsOfBundles[bundle].fiber_max = last_fiber;
 	SPECEX_INFO("restricting fiber range last fiber = " << last_fiber);
       }
-      
-      
+
+
       fitter.SelectFiberBundle(bundle);
-      
-      
+
+
       // loading arc lamp spots belonging to this bundle
       // --------------------------------------------
-      
+
       int ymin = 0; // range of usable CCD coordinates, hard coded for now
       int ymax = image.n_rows(); // range of usable CCD coordinates, hard coded for now
-      
+
       /*
       SPECEX_WARNING("RESTRICTING Y RANGE !!!!!");
       if(psf->camera_id=="b1") {ymin=696; ymax = 3516;};
       if(psf->camera_id=="b2") {ymin=696; ymax = 3516;};
-      if(psf->camera_id=="r1") {ymin=200; ymax = 3668;}; 
+      if(psf->camera_id=="r1") {ymin=200; ymax = 3668;};
       if(psf->camera_id=="r2") {ymin=200; ymax = 3668;};
       */
 
@@ -480,15 +531,15 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
       SPECEX_INFO("valid y(=rows) range = " << ymin << " " << ymax);
 
       vector<Spot_p> spots;
-      
+
       double min_wavelength = 0;
-      double max_wavelength = 1e6;  
+      double max_wavelength = 1e6;
       allocate_spots_of_bundle(spots,lamp_lines_filename,psf->FiberTraces,bundle,psf->ParamsOfBundles[bundle].fiber_min,psf->ParamsOfBundles[bundle].fiber_max,ymin,ymax,min_wavelength,max_wavelength);
       SPECEX_INFO("number of spots = " << spots.size());
-      
+
       if(write_tmp_results)
 	write_spots_xml(spots,"spots-init.xml");
-      
+
       /* DEBUGGING
       {
 	for(int fiber=psf->ParamsOfBundles[bundle].fiber_min; fiber <= psf->ParamsOfBundles[bundle].fiber_max ;fiber ++) {
@@ -501,7 +552,7 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
 	exit(12);
       }
       */
-      
+
 
       // starting fit
       // --------------------------------------------
@@ -514,53 +565,53 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
       SPECEX_INFO("Bundle " << bundle << " PSF fit ndata    = "<< psf->ParamsOfBundles[bundle].ndata);
       SPECEX_INFO("Bundle " << bundle << " PSF fit nspots   = "<< psf->ParamsOfBundles[bundle].nspots_in_fit);
       SPECEX_INFO("Bundle " << bundle << " PSF fit chi2/ndata (core) = "<< psf->ParamsOfBundles[bundle].chi2_in_core << "/" << psf->ParamsOfBundles[bundle].ndata_in_core << " = " << psf->ParamsOfBundles[bundle].chi2_in_core/psf->ParamsOfBundles[bundle].ndata_in_core);
-      
+
 
       if(bundle == first_fiber_bundle) {
 	first_fitted_fiber=psf->ParamsOfBundles[bundle].fiber_min;
 	last_fitted_fiber=psf->ParamsOfBundles[bundle].fiber_max;
       }
-      
+
       first_fitted_fiber=min(first_fitted_fiber,psf->ParamsOfBundles[bundle].fiber_min);
       last_fitted_fiber=max(last_fitted_fiber,psf->ParamsOfBundles[bundle].fiber_max);
-      
-      
+
+
       for(size_t s=0;s<spots.size();s++) {
 	fitted_spots.push_back(spots[s]);
       }
 
 
-      
+
 
       if(fit_individual_spots_position) // for debugging
 	fitter.FitIndividualSpotPositions(spots);
 
-      
+
 
     } // end of loop on bundles
-    
-    
+
+
     if(output_xml_filename != "")
       write_psf_xml(fitter.psf,output_xml_filename);
     if(output_fits_filename != "")
       write_psf_fits(fitter.psf,output_fits_filename,&fitted_spots);
     if(output_spots_filename != "")
       write_spots_xml(fitted_spots,output_spots_filename);
-    
+
 
 
     //write_psf_fits_image(fitter.psf,"psf.fits",500,2000,1,4);
 
 
-    
-    
-    
-    
-    
+
+
+
+
+
   // ending
   // --------------------------------------------
-    
-   
+
+
   } catch(harp::exception e) {
     cerr << "FATAL ERROR (harp) " << e.what() << endl;
     return EXIT_FAILURE;
@@ -573,7 +624,7 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
     cerr << "FATAL ERROR (unknown)" << endl;
     return EXIT_FAILURE;
  }
-  
+
   // may prevent crashing on non-floating point exceptions outside this function
   fedisableexcept (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW);
   return EXIT_SUCCESS;
@@ -581,5 +632,3 @@ int specex_desi_psf_fit_main ( int argc, char *argv[] ) {
 
 
 #include <specex_serialization_implement.h>
-
-


### PR DESCRIPTION
Add a timeout option to specex_desi_main (and the program desi_psf_fit).

If set, the main function will throw a  std::runtime_error exception if the fit exceeds this value.
The value is defined in seconds.

Example
```
desi_psf_fit -a /project/projectdirs/desi/spectro/redux/jguy/preproc/20201114/00062809/preproc-r0-00062809.fits --in-psf /project/projectdirs/desi/spectro/redux/jguy/exposures/20201114/00062809/fit-psf-r0-00062809.fits --first-bundle 0 --last-bundle 0 --out-psf psf-r0-0.fits --timeout 5

...

ERROR timeout, fit exceeds 5 seconds
terminate called after throwing an instance of 'std::runtime_error'
  what():  Timeout
Aborted (core dumped)

```
