### PR TITLE
Rm poptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ target_include_directories(_libspecex
 target_link_directories(_libspecex
 	PUBLIC)
 	
-target_link_libraries(_libspecex PUBLIC "-lcfitsio -lboost_program_options-mt" ${BLAS_LIBRARIES})
+target_link_libraries(_libspecex PUBLIC {BLAS_LIBRARIES})
 
 set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ target_include_directories(_libspecex
 target_link_directories(_libspecex
 	PUBLIC)
 	
-target_link_libraries(_libspecex PUBLIC {BLAS_LIBRARIES})
+target_link_libraries(_libspecex PUBLIC ${BLAS_LIBRARIES})
 
 set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
-
 # specex
 
 This repository contains code for PSF measurement in fiber-fed spectrograph for DESI.
 
 ## Introduction
 
-Package for PSF measurement in fiber-fed spectrograph (BOSS data, DESI simulations).
-This package is intended to be used with [HARP](https://github.com/tskisner/HARP) and
-/or [specter](https://github.com/desihub/specter) extraction codes.
-The installation procedure is described in the [INSTALL file](INSTALL.md), as well as below. The code depends on HARP and uses pybind11 (2.2.0)
+This package is intended to be used with the [specter](https://github.com/desihub/specter) extraction code.
+The installation procedure is described in the [INSTALL file](INSTALL.md), as well as below. The code uses pybind11 (2.2.0)
 
 ## Installation
 

--- a/py/specex/specex.py
+++ b/py/specex/specex.py
@@ -20,7 +20,7 @@ def run_specex(com):
     spxargs = VectorString()
     for strs in com:
         spxargs.append(strs)
-        
+
     # parse args
     opts.parse(spxargs)
 

--- a/src/specex_pyfitting.cc
+++ b/src/specex_pyfitting.cc
@@ -62,41 +62,6 @@ int specex::PyFitting::fit_psf(
 
   // copy to local psf pointer 
   specex::PSF_p psf = pyps.psf;
-
-#ifndef GETOPT
-
-  // set logging info
-  
-  specex_set_debug(opts.vm.count("debug")>0);
-  specex_set_verbose(opts.vm.count("quiet")==0);
-  specex_set_dump_core(opts.vm.count("core")>0);
-  
-  bool fit_traces = (opts.vm.count("no-trace-fit")==0);
-  bool fit_sigmas = (opts.vm.count("no-sigma-fit")==0);
-  bool fit_thepsf = (opts.vm.count("no-psf-fit")==0);
-  if (opts.vm.count("only-trace-fit")>0) {
-    if (opts.vm.count("no-trace-fit")>0) {
-      SPECEX_ERROR("cannot have both options --only-trace-fit and --no-trace-fit");
-      return EXIT_FAILURE;
-    }
-    opts.fit_traces = true;
-    opts.fit_sigmas = false;
-    opts.fit_thepsf = false;      
-  }
-  
-  opts.single_bundle = (opts.vm.count("single-bundle")>0);
-  
-  opts.write_tmp_results = (opts.vm.count("tmp-results")>0);
-
-#ifdef EXTERNAL_TAIL
-  opts.fit_psf_tails = (opts.vm.count("fit-psf-tails")>0);
-#endif
-#ifdef CONTINUUM
-  opts.fit_continuum = (opts.vm.count("fit-continuum")>0);
-#endif
-  opts.use_variance_model = (opts.vm.count("variance-model")>0);
-  opts.fit_individual_spots_position = opts.vm.count("positions");
-#endif
   
   SPECEX_INFO("using lamp lines file " << opts.lamp_lines_filename); 
   

--- a/src/specex_pyfitting.cc
+++ b/src/specex_pyfitting.cc
@@ -65,10 +65,7 @@ int specex::PyFitting::fit_psf(
 
   // set logging info
 
-  specex_set_debug(opts.vm.count("debug")>0);
-  specex_set_verbose(opts.vm.count("quiet")==0);
-  specex_set_dump_core(opts.vm.count("core")>0);
-
+  /*
   bool fit_traces = (opts.vm.count("no-trace-fit")==0);
   bool fit_sigmas = (opts.vm.count("no-sigma-fit")==0);
   bool fit_thepsf = (opts.vm.count("no-psf-fit")==0);
@@ -85,9 +82,11 @@ int specex::PyFitting::fit_psf(
   bool single_bundle = (opts.vm.count("single-bundle")>0);
   
   bool write_tmp_results = (opts.vm.count("tmp-results")>0);
+  */
   
   if(opts.trace_prior_deg>0) SPECEX_INFO("Will apply a prior on the traces high order terms in a bundle");
-    
+
+  /*
 #ifdef EXTERNAL_TAIL
   bool fit_psf_tails = (opts.vm.count("fit-psf-tails")>0);
 #endif
@@ -96,7 +95,7 @@ int specex::PyFitting::fit_psf(
 #endif
   bool use_variance_model = (opts.vm.count("variance-model")>0);
   bool fit_individual_spots_position = opts.vm.count("positions");
-  
+  */
   SPECEX_INFO("using lamp lines file " << opts.lamp_lines_filename); 
   
   // set broken fibers
@@ -121,7 +120,7 @@ int specex::PyFitting::fit_psf(
   
   // bundle sizes
   int number_of_fibers_per_bundle=0;
-  if(single_bundle) {
+  if(opts.single_bundle) {
     number_of_fibers_per_bundle = psf->FiberTraces.size();
   }else {
     number_of_fibers_per_bundle = eval_bundle_size(psf->FiberTraces);
@@ -145,22 +144,22 @@ int specex::PyFitting::fit_psf(
     fitter.polynomial_degree_along_wave = opts.legendre_deg_wave;
     fitter.psf->psf_error               = opts.psf_error;
     fitter.corefootprint_weight_bst     = opts.psf_core_wscale;
-    fitter.write_tmp_results            = write_tmp_results;
+    fitter.write_tmp_results            = opts.write_tmp_results;
     fitter.trace_prior_deg              = opts.trace_prior_deg;
     
 #ifdef EXTERNAL_TAIL
-    fitter.scheduled_fit_of_psf_tail    = fit_psf_tails;
+    fitter.scheduled_fit_of_psf_tail    = opts.fit_psf_tails;
 #endif
 
 #ifdef CONTINUUM
-    fitter.scheduled_fit_of_continuum   = fit_continuum;
+    fitter.scheduled_fit_of_continuum   = opts.fit_continuum;
 #endif
 
-    fitter.scheduled_fit_with_weight_model  = use_variance_model;
+    fitter.scheduled_fit_with_weight_model  = opts.use_variance_model;
     
-    fitter.scheduled_fit_of_traces      = fit_traces;
-    fitter.scheduled_fit_of_sigmas      = fit_sigmas;
-    fitter.scheduled_fit_of_psf         = fit_thepsf;
+    fitter.scheduled_fit_of_traces      = opts.fit_traces;
+    fitter.scheduled_fit_of_sigmas      = opts.fit_sigmas;
+    fitter.scheduled_fit_of_psf         = opts.fit_thepsf;
     fitter.direct_simultaneous_fit      = true; // use_input_specex_psf;
     fitter.max_number_of_lines          = opts.max_number_of_lines;
     
@@ -272,7 +271,7 @@ int specex::PyFitting::fit_psf(
 	pyps.fitted_spots.push_back(spots[s]);
       }
 
-      if(fit_individual_spots_position) // for debugging
+      if(opts.fit_individual_spots_position) // for debugging
 	fitter.FitIndividualSpotPositions(spots);
 
     } // end of loop on bundles

--- a/src/specex_pyfitting.cc
+++ b/src/specex_pyfitting.cc
@@ -63,9 +63,14 @@ int specex::PyFitting::fit_psf(
   // copy to local psf pointer 
   specex::PSF_p psf = pyps.psf;
 
-  // set logging info
+#ifndef GETOPT
 
-  /*
+  // set logging info
+  
+  specex_set_debug(opts.vm.count("debug")>0);
+  specex_set_verbose(opts.vm.count("quiet")==0);
+  specex_set_dump_core(opts.vm.count("core")>0);
+  
   bool fit_traces = (opts.vm.count("no-trace-fit")==0);
   bool fit_sigmas = (opts.vm.count("no-sigma-fit")==0);
   bool fit_thepsf = (opts.vm.count("no-psf-fit")==0);
@@ -74,30 +79,29 @@ int specex::PyFitting::fit_psf(
       SPECEX_ERROR("cannot have both options --only-trace-fit and --no-trace-fit");
       return EXIT_FAILURE;
     }
-    fit_traces = true;
-    fit_sigmas = false;
-    fit_thepsf = false;      
+    opts.fit_traces = true;
+    opts.fit_sigmas = false;
+    opts.fit_thepsf = false;      
   }
   
-  bool single_bundle = (opts.vm.count("single-bundle")>0);
+  opts.single_bundle = (opts.vm.count("single-bundle")>0);
   
-  bool write_tmp_results = (opts.vm.count("tmp-results")>0);
-  */
+  opts.write_tmp_results = (opts.vm.count("tmp-results")>0);
+
+#ifdef EXTERNAL_TAIL
+  opts.fit_psf_tails = (opts.vm.count("fit-psf-tails")>0);
+#endif
+#ifdef CONTINUUM
+  opts.fit_continuum = (opts.vm.count("fit-continuum")>0);
+#endif
+  opts.use_variance_model = (opts.vm.count("variance-model")>0);
+  opts.fit_individual_spots_position = opts.vm.count("positions");
+#endif
+  
+  SPECEX_INFO("using lamp lines file " << opts.lamp_lines_filename); 
   
   if(opts.trace_prior_deg>0) SPECEX_INFO("Will apply a prior on the traces high order terms in a bundle");
 
-  /*
-#ifdef EXTERNAL_TAIL
-  bool fit_psf_tails = (opts.vm.count("fit-psf-tails")>0);
-#endif
-#ifdef CONTINUUM
-  bool fit_continuum = (opts.vm.count("fit-continuum")>0);
-#endif
-  bool use_variance_model = (opts.vm.count("variance-model")>0);
-  bool fit_individual_spots_position = opts.vm.count("positions");
-  */
-  SPECEX_INFO("using lamp lines file " << opts.lamp_lines_filename); 
-  
   // set broken fibers
   
   vector<string> tokens = split(opts.broken_fibers_string,',');

--- a/src/specex_pyio.cc
+++ b/src/specex_pyio.cc
@@ -31,16 +31,6 @@ int specex::PyIO::set_inputpsf(specex::PyOptions opts){
   
   use_input_specex_psf = true;
 
-#ifndef GETOPT
-  psf_change_req |= (! opts.vm["half-size-x"].defaulted());
-  psf_change_req |= (! opts.vm["half-size-y"].defaulted());
-  psf_change_req |= (! opts.vm["gauss-hermite-deg"].defaulted());
-  psf_change_req |= (! opts.vm["gauss-hermite-deg2"].defaulted());
-  psf_change_req |= (! opts.vm["legendre-deg-wave"].defaulted());
-  psf_change_req |= (! opts.vm["legendre-deg-x"].defaulted());
-  psf_change_req |= (! opts.vm["trace-deg-wave"].defaulted());
-  psf_change_req |= (! opts.vm["trace-deg-x"].defaulted());  
-#else
   psf_change_req |= (! opts.half_size_x_def);
   psf_change_req |= (! opts.half_size_y_def);
   psf_change_req |= (! opts.gauss_hermite_deg_def);
@@ -49,7 +39,6 @@ int specex::PyIO::set_inputpsf(specex::PyOptions opts){
   psf_change_req |= (! opts.legendre_deg_x_def);
   psf_change_req |= (! opts.trace_deg_wave_def);
   psf_change_req |= (! opts.trace_deg_x_def);
-#endif
   
   if(psf_change_req && use_input_specex_psf) {
     SPECEX_WARNING("option(s) were given to specify the psf properties, so we cannot use the input PSF parameters as a starting point (except for the trace coordinates)");

--- a/src/specex_pyio.cc
+++ b/src/specex_pyio.cc
@@ -31,6 +31,7 @@ int specex::PyIO::set_inputpsf(specex::PyOptions opts){
   
   use_input_specex_psf = true;
 
+#ifndef GETOPT
   psf_change_req |= (! opts.vm["half-size-x"].defaulted());
   psf_change_req |= (! opts.vm["half-size-y"].defaulted());
   psf_change_req |= (! opts.vm["gauss-hermite-deg"].defaulted());
@@ -38,7 +39,17 @@ int specex::PyIO::set_inputpsf(specex::PyOptions opts){
   psf_change_req |= (! opts.vm["legendre-deg-wave"].defaulted());
   psf_change_req |= (! opts.vm["legendre-deg-x"].defaulted());
   psf_change_req |= (! opts.vm["trace-deg-wave"].defaulted());
-  psf_change_req |= (! opts.vm["trace-deg-x"].defaulted());
+  psf_change_req |= (! opts.vm["trace-deg-x"].defaulted());  
+#else
+  psf_change_req |= (! opts.half_size_x_def);
+  psf_change_req |= (! opts.half_size_y_def);
+  psf_change_req |= (! opts.gauss_hermite_deg_def);
+  psf_change_req |= (! opts.gauss_hermite_deg2_def);
+  psf_change_req |= (! opts.legendre_deg_wave_def);
+  psf_change_req |= (! opts.legendre_deg_x_def);
+  psf_change_req |= (! opts.trace_deg_wave_def);
+  psf_change_req |= (! opts.trace_deg_x_def);
+#endif
   
   if(psf_change_req && use_input_specex_psf) {
     SPECEX_WARNING("option(s) were given to specify the psf properties, so we cannot use the input PSF parameters as a starting point (except for the trace coordinates)");

--- a/src/specex_pyoptions.cc
+++ b/src/specex_pyoptions.cc
@@ -4,8 +4,10 @@
 
 using namespace std;
 
-namespace popts = boost::program_options;
-
+#ifdef GETOPT
+int specex::PyOptions::parse(int argc, char *argv[] ){
+}
+#else
 int specex::PyOptions::parse(int argc, char *argv[] ){
 
   // reading arguments
@@ -106,4 +108,4 @@ int specex::PyOptions::parse(int argc, char *argv[] ){
   return EXIT_SUCCESS;
   
 }
-
+#endif

--- a/src/specex_pyoptions.cc
+++ b/src/specex_pyoptions.cc
@@ -155,6 +155,7 @@ int specex::PyOptions::parse(int argc, char *argv[] )
 
   while (true)
     {
+
       const auto opt = getopt_long(argc, argv, short_opts, long_opts, nullptr);
 
       if (opt == -1){
@@ -271,6 +272,9 @@ int specex::PyOptions::parse(int argc, char *argv[] )
       }
     }
 
+  // reset the index of the option to be read from argv in case get_opt is invoked again
+  optind = 1;
+  
   return EXIT_SUCCESS;
   
 }

--- a/src/specex_pyoptions.cc
+++ b/src/specex_pyoptions.cc
@@ -5,9 +5,241 @@
 using namespace std;
 
 #ifdef GETOPT
-int specex::PyOptions::parse(int argc, char *argv[] ){
+
+void PrintHelp()
+{
+  std::cout <<
+    "--help,-h             display usage information\n" 
+    "--arc,-a              preprocessed fits image file name (mandatory)\n" 
+    "--in-psf              input psf file name (fits or xml, can contain only the traces, mandatory)\n"  
+    "--out-psf             output psf fits file name (mandatory)\n"
+    "--lamp-lines          input lamp lines file name (mandatory)\n" 
+    "--only-trace-fit      only fit the trace coordinates (default is trace,sigma,psf)\n"
+    "--no-trace-fit        do not fit the trace coordinates (default is trace,sigma,psf)\n"
+    "--no-sigma-fit        do not fit the gaussian sigma (default is trace,sigma,psf)\n"
+    "--no-psf-fit          do not fit the psf (default is trace,sigma,psf)\n"
+    "--flux-hdu            flux hdu in input arc fits, for unusual data format\n"
+    "--ivar-hdu            ivar hdu in input arc fits, for unusual data format\n"
+    "--mask-hdu            mask hdu in input arc fits, for unusual data format\n"
+    "--header-hdu          header hdu in input arc fits, for unusual data format\n"
+    "--xcoord-hdu          hdu of x trace legendre polynomial of wavelength (default is extension XTRACE)\n" 
+    "--ycoord-hdu          hdu of y trace legendre polynomial of wavelength (default is extension YTRACE)\n" 
+    "--first-bundle        first fiber bundle to fit\n"
+    "--last-bundle         last fiber bundle to fit\n"
+    "--single-bundle       fit a single bundle with all fibers\n"
+    "--first-fiber         first fiber (must be in bundle)\n"
+    "--last-fiber          last fiber (must be in bundle)\n"
+    "--half-size-x         half size of PSF stamp (full size is 2*half_size+1)\n"
+    "--half-size-y         half size of PSF stamp (full size is 2*half_size+1)\n"
+    "--psfmodel            PSF model, default is GAUSSHERMITE\n"
+    "--positions           fit positions of each spot individually after global fit for debugging\n"
+    "--verbose,v           turn on verbose mode (deprecated, true by default)\n" 
+    "--quiet               no info message, only warning\n" 
+    "--debug               turn on debug mode\n" 
+    "--trace-prior-deg     force equal trace coeff in bundle starting at this degree\n"
+    "--lamplines           lamp lines ASCII file name (def. is $SPECEXDATA/specex_linelist_desi.txt)\n" 
+    "--core                dump core files when an exception is thrown\n"
+    "--gauss-hermite-deg   degree of Hermite polynomials (same for x and y, only if GAUSSHERMITE psf)\n"
+    "--gauss-hermite-deg2  degree of Hermite polynomials (same for x and y, only if GAUSSHERMITE2 psf)\n"
+    "--legendre-deg-wave   degree of Legendre polynomials along wavelength (can be reduced if missing data)\n"
+    "--legendre-deg-x      degree of Legendre polynomials along x_ccd (can be reduced if missing data)\n"
+    "--trace-deg-wave      degree of Legendre polynomials along wavelength for fit of traces\n"
+    "--trace-deg-x         degree of Legendre polynomials along x_ccd for fit of traces\n"
+    "--psf-error           psf fractional uncertainty (default is 0.01, for weights in the fit)\n"
+    "--psf-core-wscale     scale up the weight of pixels in 5x5 PSF core\n"
+    "--broken-fibers       broken fibers (comma separated list)\n"
+
+    "--variance-model      refit at the end with a model of the variance to avoid Poisson noise bias\n"    
+    "--out-psf-xml         output psf xml file name\n"
+    "--out-spots           output spots file name\n"  
+    "--prior               gaussian prior on a param : 'name' value error\n"  
+    "--tmp_results         write tmp results\n"  
+#ifdef EXTERNAL_TAIL
+    "--fit-psf-tails       unable fit of psf tails\n"
+#endif
+#ifdef CONTINUUM
+    "--fit-continuum       unable fit of continuum\n"
+#endif
+    "--nlines              max # emission lines used (uses an algorithm to select best ones \n"
+    "                      based on S/N and line coverage\n"
+    
+    exit(1);
 }
+
+int specex::PyOptions::parse(int argc, char *argv[] )
+{
+  const char* const short_opts = "n:bs:w:h";
+  const option long_opts[] = {
+    {"help",               required_argument, nullptr, 'h'},
+    {"arc"                 required_argument, nullptr, 'arc'},
+    {"verbose",            optional_argument, nullptr, 'ver'},
+    {"in-psf",             required_argument, nullptr, 'ip'},
+    {"out-psf",            required_argument, nullptr, 'op'},
+    {"lamp-lines",         required_argument, nullptr, 'll'},
+    {"only-trace-fit",     optional_argument, nullptr, 'otf'},
+    {"no-trace-fit",       optional_argument, nullptr, 'ntf'},
+    {"no-sigma-fit",       optional_argument, nullptr, 'nsf'},
+    {"no-psf-fit",         optional_argument, nullptr, 'npf'},
+    {"flux-hdu",           optional_argument, nullptr, 'fh'},
+    {"ivar-hdu",           optional_argument, nullptr, 'ih'},
+    {"mask-hdu",           optional_argument, nullptr, 'mh'},
+    {"header-hdu",         optional_argument, nullptr, 'hh'},
+    {"xcoord-hdu",         optional_argument, nullptr, 'xh'},
+    {"ycoord-hdu ",        optional_argument, nullptr, 'yh'},
+    {"first-bundle",       optional_argument, nullptr, 'fb'},
+    {"last-bundle",        optional_argument, nullptr, 'lb'},
+    {"single-bundle",      optional_argument, nullptr, 'sb'},
+    {"first-fiber",        optional_argument, nullptr, 'ff'}, 
+    {"last-fiber",         optional_argument, nullptr, 'lf'},
+    {"half-size-x",        optional_argument, nullptr, 'hsx'},
+    {"half-size-y",        optional_argument, nullptr, 'hsy'},
+    {"psfmodel",           optional_argument, nullptr, 'pm'},
+    {"positions",          optional_argument, nullptr, 'pos'},
+    {"quiet",              optional_argument, nullptr, 'q'},
+    {"debug",              optional_argument, nullptr, 'd'},
+    {"trace-prior-deg",    optional_argument, nullptr, 'tpd'},
+    {"lamplines",          optional_argument, nullptr, 'll'},
+    {"core",               optional_argument, nullptr, 'c'},
+    {"gauss-hermite-deg",  optional_argument, nullptr, 'qhd'},
+    {"gauss-hermite-deg2", optional_argument, nullptr, 'qhd2'},
+    {"legendre-deg-wave",  optional_argument, nullptr, 'ldw'},
+    {"legendre-deg-x",     optional_argument, nullptr, 'ldx'},
+    {"trace-deg-wave",     optional_argument, nullptr, 'tdw'},
+    {"trace-deg-x",        optional_argument, nullptr, 'tdx'},
+    {"psf-error",          optional_argument, nullptr, 'pe'},
+    {"psf-core-wscale",    optional_argument, nullptr, 'pcw'},
+    {"broken-fibers",      optional_argument, nullptr, 'bf'},
+    {"variance-model",     optional_argument, nullptr, 'vm'},
+    {"out-psf-xml",        optional_argument, nullptr, 'opx'},
+    {"out-spots",          optional_argument, nullptr, 'os'},
+    {"prior",              optional_argument, nullptr, 'p'},
+    {"tmp_results",        optional_argument, nullptr, 'tr'},
+#ifdef EXTERNAL_TAIL
+    {"fit-psf-tails",      optional_argument, nullptr, 'fpt'},
+#endif
+#ifdef CONTINUUM
+    {"fit-continuum",      optional_argument, nullptr, 'fc'},
+#endif
+    {"nlines",             optional_argument, nullptr, 'nl'}
+  };
+  
+  const char* const short_opts = "ha:v";
+  
+  while (true)
+    {
+      const auto opt = getopt_long(argc, argv, short_opts, long_opts, nullptr);
+      
+      if (-1 == opt)
+	break;
+      
+      switch (opt)
+	{
+	case 'h':
+	  PrintHelp(); break;	  
+	case 'arc':
+	  arc_image_filename = std::string(optarg); break;	  
+	case 'ver':
+	case 'ip':
+	  input_psf_filename = std::string(optarg); break;	  
+	case 'op':
+	  output_fits_filename = std::string(optarg); break;	  
+	case 'll':
+	  lamp_lines_fileanem = std::string(optarg); break;	  
+	case 'otf':
+	  fit_traces = true;
+	  fit_sigmas = true;
+	  fit_thepsf = true;
+	  break;
+	case 'ntf':
+	  fit_traces = false; break;	  
+	case 'nsf':
+	  fit_sigmas = false; break;
+	case 'npf':
+	  fit_thepsf = false; break;
+	case 'fh':
+	  flux_hdu = std::stoi(optarg); break;
+	case 'ih':
+	  ivar_hdu = std::stoi(optarg); break;
+	case 'mh':
+	  mask_hdu = std::stoi(optarg); break;
+	case 'hh':
+	  header_hdu = std::stoi(optarg); break;
+	case 'xh':
+	  xtrace_hdu = std::stoi(optarg); break;
+	case 'yh':
+	  ytrace_hdu = std::stoi(optarg); break;
+	case 'fb':
+	  first_fiber_bundle = std::stoi(optarg); break;
+	case 'lb':
+	  last_fiber_bundle = std::stoi(optarg); break;
+	case 'sb':
+	  single_bundle = true; break;
+	case 'ff':	  
+	  first_fiber = std::stoi(optarg); break;
+	case 'lf':
+	  last_fiber = std::stoi(optarg); break;
+	case 'hsx':
+	  half_size_x = std::stoi(optarg); break;  
+	case 'hsy':
+	  half_size_y = std::stoi(optarg); break;
+	case 'pm':
+	  psf_model = std::stoi(optarg); break;
+	case 'pos':
+	  break;
+	case 'q':
+	  specex_set_verbose(true); break;
+	case 'd':
+	  specex_set_debug(true); break;
+	case 'tpd':
+	  trace_prior_deg = std::stoi(optarg); break;
+	case 'll':
+	  lamp_lines_filename = std::string(optarg); break;
+	case 'c':
+	  specex_set_dump_core(true); break;
+	case 'qhd':
+	  gauss_hermite_deg = std::stoi(optarg); break;
+	case 'qhd2':
+	  gauss_hermite_deg2 = std::stoi(optarg); break;
+	case 'ldw':
+	  legendre_deg_wave = std::stoi(optarg); break;
+	case 'ldx':
+	  legendre_deg_x = std::stoi(optarg); break;
+	case 'tdx':
+	  trace_deg_x = std::stoi(optarg); break;
+	case 'pe':
+	  psf_error = std:stod(optarg); break;
+	case 'pcw':
+	  psf_core_wscale = std::stod(optarg); break;
+	case 'bf':
+	  broken_fibers_string = std::string(optarg); break;
+#ifdef EXTERNAL_TAIL
+	case 'fpt':
+	  fit_psf_tails = true; break;
+#endif
+#ifdef CONTINUUM
+	case 'fc':
+	   break;
+#endif
+	case 'vm':
+	  break;
+	case 'opx':
+	  output_xml_filename = std::string(optarg); break;
+	case 'os':
+	  output_spots_filename = std::string(optarg); break;
+	case 'p':
+	  argurment_priors.push_back(std::string(optarg)); break;
+	case 'tr':
+	  break;
+	case 'nl':
+	  max_number_of_lines = std:stoi(optarg); break;
+        default:
+	  PrintHelp(); break;
+        }
+    }
+}
+
 #else
+
 int specex::PyOptions::parse(int argc, char *argv[] ){
 
   // reading arguments
@@ -27,9 +259,6 @@ int specex::PyOptions::parse(int argc, char *argv[] ){
     ( "ivar-hdu", popts::value<int>( &ivar_hdu )->default_value(2), " ivar hdu in input arc fits, for unusual data format")
     ( "mask-hdu", popts::value<int>( &mask_hdu )->default_value(3), " mask hdu in input arc fits, for unusual data format")
     ( "header-hdu", popts::value<int>( &header_hdu )->default_value(1), " header hdu in input arc fits, for unusual data format")
-
-    // ( "trace", popts::value<string>( &trace_filename ), "fits image file name with image extensions XTRACE and YTRACE for legendre polynomial of wavelength (mandatory)" )
-    
     ( "xcoord-hdu", popts::value<int>( &xtrace_hdu )->default_value(-1), "hdu of x trace legendre polynomial of wavelength (default is extension XTRACE)" )
     ( "ycoord-hdu", popts::value<int>( &ytrace_hdu )->default_value(-1), "hdu of y trace legendre polynomial of wavelength (default is extension YTRACE)" )
     ( "first-bundle", popts::value<int>( &first_fiber_bundle )->default_value(0), "first fiber bundle to fit")
@@ -56,8 +285,7 @@ int specex::PyOptions::parse(int argc, char *argv[] ){
     ( "trace-deg-x",  popts::value<int>( &trace_deg_x )->default_value(6), "degree of Legendre polynomials along x_ccd for fit of traces")
     ( "psf-error",  popts::value<double>( &psf_error )->default_value(0), "psf fractional uncertainty (default is 0.01, for weights in the fit)")
     ( "psf-core-wscale",  popts::value<double>( &psf_core_wscale ), "scale up the weight of pixels in 5x5 PSF core")
-    ( "broken-fibers", popts::value<string>( &broken_fibers_string ), "broken fibers (comma separated list)")
-    
+    ( "broken-fibers", popts::value<string>( &broken_fibers_string ), "broken fibers (comma separated list)")    
 #ifdef EXTERNAL_TAIL
     ( "fit-psf-tails", "unable fit of psf tails")
 #endif

--- a/src/specex_pyoptions.cc
+++ b/src/specex_pyoptions.cc
@@ -7,8 +7,6 @@
 
 using namespace std;
 
-#ifdef GETOPT
-
 void PrintHelp()
 {
   return;
@@ -144,62 +142,6 @@ int specex::PyOptions::parse(int argc, char *argv[] )
 #endif
   loadmap(optmap, "nlines",             required_argument);
  
-  /*
-  const option long_opts[] = {
-    {"help",               required_argument, nullptr, 'h'},
-    {"arc",                required_argument, nullptr, 'arc'},
-    {"verbose",            optional_argument, nullptr, 'ver'},
-    {"in-psf",             required_argument, nullptr, 'ip'},
-    {"out-psf",            required_argument, nullptr, 'op'},
-    {"lamp-lines",         required_argument, nullptr, 'll'},
-    {"only-trace-fit",     optional_argument, nullptr, 'otf'},
-    {"no-trace-fit",       optional_argument, nullptr, 'ntf'},
-    {"no-sigma-fit",       optional_argument, nullptr, 'nsf'},
-    {"no-psf-fit",         optional_argument, nullptr, 'npf'},
-    {"flux-hdu",           optional_argument, nullptr, 'fh'},
-    {"ivar-hdu",           optional_argument, nullptr, 'ih'},
-    {"mask-hdu",           optional_argument, nullptr, 'mh'},
-    {"header-hdu",         optional_argument, nullptr, 'hh'},
-    {"xcoord-hdu",         optional_argument, nullptr, 'xh'},
-    {"ycoord-hdu ",        optional_argument, nullptr, 'yh'},
-    {"first-bundle",       optional_argument, nullptr, 'fb'},
-    {"last-bundle",        optional_argument, nullptr, 'lb'},
-    {"single-bundle",      optional_argument, nullptr, 'sb'},
-    {"first-fiber",        optional_argument, nullptr, 'ff'}, 
-    {"last-fiber",         optional_argument, nullptr, 'lf'},
-    {"half-size-x",        optional_argument, nullptr, 'hsx'},
-    {"half-size-y",        optional_argument, nullptr, 'hsy'},
-    {"psfmodel",           optional_argument, nullptr, 'pm'},
-    {"positions",          optional_argument, nullptr, 'pos'},
-    {"quiet",              optional_argument, nullptr, 'q'},
-    {"debug",              optional_argument, nullptr, 'd'},
-    {"trace-prior-deg",    optional_argument, nullptr, 'tpd'},
-    {"lamplines",          optional_argument, nullptr, 'lls'},
-    {"core",               optional_argument, nullptr, 'c'},
-    {"gauss-hermite-deg",  optional_argument, nullptr, 'ghd'},
-    {"gauss-hermite-deg2", optional_argument, nullptr, 'ghd2'},
-    {"legendre-deg-wave",  optional_argument, nullptr, 'ldw'},
-    {"legendre-deg-x",     optional_argument, nullptr, 'ldx'},
-    {"trace-deg-wave",     optional_argument, nullptr, 'tdw'},
-    {"trace-deg-x",        optional_argument, nullptr, 'tdx'},
-    {"psf-error",          optional_argument, nullptr, 'pe'},
-    {"psf-core-wscale",    optional_argument, nullptr, 'pcw'},
-    {"broken-fibers",      optional_argument, nullptr, 'bf'},
-    {"variance-model",     optional_argument, nullptr, 'vm'},
-    {"out-psf-xml",        optional_argument, nullptr, 'opx'},
-    {"out-spots",          optional_argument, nullptr, 'os'},
-    {"prior",              optional_argument, nullptr, 'p'},
-    {"tmp_results",        optional_argument, nullptr, 'tr'},
-#ifdef EXTERNAL_TAIL
-    {"fit-psf-tails",      optional_argument, nullptr, 'fpt'},
-#endif
-#ifdef CONTINUUM
-    {"fit-continuum",      optional_argument, nullptr, 'fc'},
-#endif
-    {"nlines",             optional_argument, nullptr, 'nl'}
-  };
-  */
-  
   int i = 0;
   for (it = optmap.begin(); it !=optmap.end(); it++){
     long_opts[i] = {it->first.c_str(), it->second[0], nullptr, it->second[1]}; i++;
@@ -332,103 +274,3 @@ int specex::PyOptions::parse(int argc, char *argv[] )
   return EXIT_SUCCESS;
   
 }
-
-#else
-
-int specex::PyOptions::parse(int argc, char *argv[] ){
-
-  // reading arguments
-  // --------------------------------------------
-
-  desc.add_options()
-    ( "help,h", "display usage information" )
-    ( "arc,a", popts::value<string>( &arc_image_filename ), "arc preprocessed fits image file name (mandatory)" )
-    ( "in-psf", popts::value<string>( &input_psf_filename ), " input psf file name (fits or xml, can contain only the traces, mandatory)")  
-    ( "out-psf", popts::value<string>( &output_fits_filename ), " output psf fits file name (mandatory)")
-    ( "lamp-lines", popts::value<string>(&lamp_lines_filename ), " input lamp lines file name (mandatory)") 
-    ( "only-trace-fit", "only fit the trace coordinates (default is trace,sigma,psf)")
-    ( "no-trace-fit", "do not fit the trace coordinates (default is trace,sigma,psf)")
-    ( "no-sigma-fit", "do not fit the gaussian sigma (default is trace,sigma,psf)")
-    ( "no-psf-fit", "do not fit the psf (default is trace,sigma,psf)")
-    ( "flux-hdu", popts::value<int>( &flux_hdu )->default_value(1), " flux hdu in input arc fits, for unusual data format")
-    ( "ivar-hdu", popts::value<int>( &ivar_hdu )->default_value(2), " ivar hdu in input arc fits, for unusual data format")
-    ( "mask-hdu", popts::value<int>( &mask_hdu )->default_value(3), " mask hdu in input arc fits, for unusual data format")
-    ( "header-hdu", popts::value<int>( &header_hdu )->default_value(1), " header hdu in input arc fits, for unusual data format")
-    ( "xcoord-hdu", popts::value<int>( &xtrace_hdu )->default_value(-1), "hdu of x trace legendre polynomial of wavelength (default is extension XTRACE)" )
-    ( "ycoord-hdu", popts::value<int>( &ytrace_hdu )->default_value(-1), "hdu of y trace legendre polynomial of wavelength (default is extension YTRACE)" )
-    ( "first-bundle", popts::value<int>( &first_fiber_bundle )->default_value(0), "first fiber bundle to fit")
-    ( "last-bundle", popts::value<int>( &last_fiber_bundle )->default_value(0), "last fiber bundle to fit")
-    ( "single-bundle", "fit a single bundle with all fibers")
-    ( "first-fiber", popts::value<int>( &first_fiber )->default_value(0), "first fiber (must be in bundle)")
-    ( "last-fiber", popts::value<int>( &last_fiber )->default_value(100000), "last fiber (must be in bundle)")
-    ( "half-size-x", popts::value<int>( &half_size_x )->default_value(8), "half size of PSF stamp (full size is 2*half_size+1)")
-    ( "half-size-y", popts::value<int>( &half_size_y )->default_value(5), "half size of PSF stamp (full size is 2*half_size+1)")
-    ( "psfmodel", popts::value<string>( &psf_model )->default_value("GAUSSHERMITE"), "PSF model, default is GAUSSHERMITE")
-    ( "positions", "fit positions of each spot individually after global fit for debugging")
-    ( "verbose,v", "turn on verbose mode (deprecated, true by default)" )
-    ( "quiet", "no info message, only warning" )
-    ( "debug", "turn on debug mode" )
-    ( "trace-prior-deg", popts::value<int>( &trace_prior_deg )->default_value(0) , "force equal trace coeff in bundle starting at this degree")
-    ( "lamplines", popts::value<string>( &lamp_lines_filename ), "lamp lines ASCII file name (def. is $SPECEXDATA/specex_linelist_desi.txt)" )
-    ( "core", "dump core files when an exception is thrown" )
-    ( "gauss-hermite-deg",  popts::value<int>( &gauss_hermite_deg )->default_value(6), "degree of Hermite polynomials (same for x and y, only if GAUSSHERMITE psf)")
-    ("gauss-hermite-deg2",  popts::value<int>( &gauss_hermite_deg2 )->default_value(2), "degree of Hermite polynomials (same for x and y, only if GAUSSHERMITE2 psf)")
-    //( "gauss_hermite_sigma",  popts::value<double>( &gauss_hermite_sigma ), "sigma of Gauss-Hermite PSF (same for x and y, only if GAUSSHERMITE psf)")
-    ( "legendre-deg-wave",  popts::value<int>( &legendre_deg_wave )->default_value(3), "degree of Legendre polynomials along wavelength (can be reduced if missing data)")
-    ( "legendre-deg-x",  popts::value<int>( &legendre_deg_x )->default_value(1), "degree of Legendre polynomials along x_ccd (can be reduced if missing data)")
-    ( "trace-deg-wave",  popts::value<int>( &trace_deg_wave )->default_value(6), "degree of Legendre polynomials along wavelength for fit of traces")
-    ( "trace-deg-x",  popts::value<int>( &trace_deg_x )->default_value(6), "degree of Legendre polynomials along x_ccd for fit of traces")
-    ( "psf-error",  popts::value<double>( &psf_error )->default_value(0), "psf fractional uncertainty (default is 0.01, for weights in the fit)")
-    ( "psf-core-wscale",  popts::value<double>( &psf_core_wscale ), "scale up the weight of pixels in 5x5 PSF core")
-    ( "broken-fibers", popts::value<string>( &broken_fibers_string ), "broken fibers (comma separated list)")    
-#ifdef EXTERNAL_TAIL
-    ( "fit-psf-tails", "unable fit of psf tails")
-#endif
-#ifdef CONTINUUM
-    ( "fit-continuum", "unable fit of continuum")
-#endif
-    ( "variance-model", "refit at the end with a model of the variance to avoid Poisson noise bias")
-    
-    ( "out-psf-xml", popts::value<string>( &output_xml_filename ), " output psf xml file name")
-   
-    ( "out-spots", popts::value<string>( &output_spots_filename ), " output spots file name")  
-    ( "prior", popts::value< vector<string> >( &argurment_priors )->multitoken(), " gaussian prior on a param : 'name' value error")  
-    ( "tmp_results", " write tmp results")  
-    ( "nlines", popts::value<int>( &max_number_of_lines )->default_value(200)," maximum number of emission lines used in fit (uses a algorithm to select best ones based on S/N and line coverage")  
-    //( "out", popts::value<string>( &outfile ), "output image file" )
-    ;
-
-  try {    
-    popts::store(popts::command_line_parser( argc, argv ).options(desc).run(), vm);
-    popts::notify(vm);
-  }catch(std::exception& e) {
-    cerr << "error in arguments : " << e.what() << endl;
-    cerr << "try --help for options" << endl;
-    return EXIT_FAILURE;
-  }
-  
-  if ( ( argc < 2 ) || vm.count( "help" ) ) {
-      cerr << endl;
-      cerr << desc << endl;      
-      return EXIT_FAILURE;
-  }
-  if ( ! vm.count( "arc" ) ) {
-    cerr << endl;
-    cerr << "missing --arc , try --help for options" << endl;      
-    return EXIT_FAILURE;
-  }
-  if ( ! vm.count( "in-psf" ) ) {
-    cerr << endl;
-    cerr << "missing --in-psf , try --help for options" << endl;      
-    return EXIT_FAILURE;
-  }    
-  if(lamp_lines_filename == "") {
-    cerr << endl;
-    cerr << "missing lamp_lines_filename either define env. variable SPECEXDATA or use option --lamplines" << endl;
-    return EXIT_FAILURE;
-  }
-
-  return EXIT_SUCCESS;
-  
-}
-#endif

--- a/src/specex_pyoptions.h
+++ b/src/specex_pyoptions.h
@@ -7,7 +7,8 @@
 #include <string>
 #include <specex_unbls.h>
 #include <specex_psf_fitter.h>
-
+#include <getopt.h>
+#include <map>
 
 #ifndef GETOPT
 #include <boost/program_options.hpp>
@@ -21,6 +22,8 @@ namespace specex {
   public :
 
     typedef std::shared_ptr <PyOptions> pshr;
+
+    int noptions;
 
     std::string arc_image_filename;
     std::string input_psf_filename; 
@@ -71,8 +74,19 @@ namespace specex {
     bool use_variance_model;
     bool fit_individual_spots_position;
     
-    int parse(int argc, char *argv[] ); 
+    bool half_size_x_def; 
+    bool half_size_y_def; 
+    bool gauss_hermite_deg_def; 
+    bool gauss_hermite_deg2_def; 
+    bool legendre_deg_wave_def; 
+    bool legendre_deg_x_def;
+    bool trace_deg_wave_def;
+    bool trace_deg_x_def; 
 
+    int parse(int argc, char *argv[] ); 
+    void loadmap(std::map<std::string,std::vector<int>>&, const string, int);
+    int argint(std::map<std::string,std::vector<int>>&, const string);
+    
     PyOptions()
 #ifndef GETOPT
       : desc(popts::options_description("Options"))
@@ -122,6 +136,15 @@ namespace specex {
       use_variance_model = false;
       fit_individual_spots_position = false;
       
+      half_size_x_def = false ;
+      half_size_y_def = false;
+      gauss_hermite_deg_def = false; 
+      gauss_hermite_deg2_def = false; 
+      legendre_deg_wave_def = false; 
+      legendre_deg_x_def = false;
+      trace_deg_wave_def = false;
+      trace_deg_x_def = false; 
+
       return;
       
     }

--- a/src/specex_pyoptions.h
+++ b/src/specex_pyoptions.h
@@ -1,7 +1,7 @@
 #ifndef SPECEX_PYOPTIONS__H
 #define SPECEX_PYOPTIONS__H
 
-//#define GETOPT
+#define GETOPT
 
 #include <vector>
 #include <string>
@@ -53,56 +53,74 @@ namespace specex {
     int max_number_of_lines; 
     
     std::string broken_fibers_string;
-
     std::string lamp_lines_filename;
-
     std::vector<std::string> argurment_priors;
-
-    popts::variables_map vm;
-
+        
+#ifndef GETOPT
+    popts::variables_map vm;    
     popts::options_description desc;
-
+#endif
+    
+    bool fit_traces;
+    bool fit_sigmas;
+    bool fit_thepsf;
+    bool single_bundle;
+    bool write_tmp_results;
+    bool fit_psf_tails;
+    bool fit_continuum;
+    bool use_variance_model;
+    bool fit_individual_spots_position;
+    
     int parse(int argc, char *argv[] ); 
 
     PyOptions()
 #ifndef GETOPT
       : desc(popts::options_description("Options"))
 #endif
-      {
-        
+      {	
       arc_image_filename="";
       input_psf_filename="";
       output_xml_filename="";
       output_fits_filename="";
       output_spots_filename="";
-      flux_hdu=0;
-      ivar_hdu=0;
-      mask_hdu=0;
-      header_hdu=0;
-      xtrace_hdu=0;
-      ytrace_hdu=0;
+      flux_hdu=1;
+      ivar_hdu=2;
+      mask_hdu=3;
+      header_hdu=1;
+      xtrace_hdu=-1;
+      ytrace_hdu=-1;
     
-      psf_model="";
+      psf_model="GAUSSHERMITE";
       first_fiber_bundle=0;
       last_fiber_bundle=0;
       first_fiber=0;
-      last_fiber=0;
-      half_size_x=0;
-      half_size_y=0;  
-      gauss_hermite_deg=0;
-      gauss_hermite_deg2=0; 
-      legendre_deg_wave=0;
-      legendre_deg_x=0;
-      trace_deg_wave=0;
-      trace_deg_x=0;  
+      last_fiber=100000;
+      half_size_x=8;
+      half_size_y=5;  
+      gauss_hermite_deg=6;
+      gauss_hermite_deg2=2; 
+      legendre_deg_wave=3;
+      legendre_deg_x=1;
+      trace_deg_wave=6;
+      trace_deg_x=6;  
       trace_prior_deg=0;
       psf_error=0;
       psf_core_wscale=0;
-      max_number_of_lines=0; 
+      max_number_of_lines=200; 
     
       broken_fibers_string="";
 
       lamp_lines_filename="";
+
+      fit_traces = true;
+      fit_sigmas = true;
+      fit_thepsf = true;
+      single_bundle = false;
+      write_tmp_results = false;
+      fit_psf_tails = false;
+      fit_continuum = false;
+      use_variance_model = false;
+      fit_individual_spots_position = false;
       
       return;
       

--- a/src/specex_pyoptions.h
+++ b/src/specex_pyoptions.h
@@ -1,15 +1,18 @@
 #ifndef SPECEX_PYOPTIONS__H
 #define SPECEX_PYOPTIONS__H
 
-#include <boost/program_options.hpp>
+//#define GETOPT
+
 #include <vector>
 #include <string>
-
 #include <specex_unbls.h>
-
 #include <specex_psf_fitter.h>
 
+
+#ifndef GETOPT
+#include <boost/program_options.hpp>
 namespace popts = boost::program_options;
+#endif
 
 namespace specex {
   
@@ -62,7 +65,9 @@ namespace specex {
     int parse(int argc, char *argv[] ); 
 
     PyOptions()
-      : desc(popts::options_description("Options")) 
+#ifndef GETOPT
+      : desc(popts::options_description("Options"))
+#endif
       {
         
       arc_image_filename="";

--- a/src/specex_pyoptions.h
+++ b/src/specex_pyoptions.h
@@ -1,19 +1,12 @@
 #ifndef SPECEX_PYOPTIONS__H
 #define SPECEX_PYOPTIONS__H
 
-#define GETOPT
-
 #include <vector>
 #include <string>
 #include <specex_unbls.h>
 #include <specex_psf_fitter.h>
 #include <getopt.h>
 #include <map>
-
-#ifndef GETOPT
-#include <boost/program_options.hpp>
-namespace popts = boost::program_options;
-#endif
 
 namespace specex {
   
@@ -59,11 +52,6 @@ namespace specex {
     std::string lamp_lines_filename;
     std::vector<std::string> argurment_priors;
         
-#ifndef GETOPT
-    popts::variables_map vm;    
-    popts::options_description desc;
-#endif
-    
     bool fit_traces;
     bool fit_sigmas;
     bool fit_thepsf;
@@ -88,9 +76,6 @@ namespace specex {
     int argint(std::map<std::string,std::vector<int>>&, const string);
     
     PyOptions()
-#ifndef GETOPT
-      : desc(popts::options_description("Options"))
-#endif
       {	
       arc_image_filename="";
       input_psf_filename="";

--- a/src/specex_pyprior.cc
+++ b/src/specex_pyprior.cc
@@ -12,7 +12,6 @@ int specex::PyPrior::set_priors(specex::PyOptions opts){
     int np=int(opts.argurment_priors.size());
     if( ! (np%3==0) ) {
       cerr << "error in parsing, priors must be of the form 'name value error' (np=" << np << ")" << endl;
-      cerr << opts.desc << endl;
       return EXIT_FAILURE;
     }
     try {
@@ -26,7 +25,6 @@ int specex::PyPrior::set_priors(specex::PyOptions opts){
     }catch(std::exception) {
       cerr << "error in parsing arguments of priors" << endl;
       cerr << "priors must be of the form 'name value error'" << endl;
-      cerr << opts.desc << endl;
       return EXIT_FAILURE;
     } 
   }

--- a/testing/test-io_refactor.sh
+++ b/testing/test-io_refactor.sh
@@ -2,7 +2,7 @@
 build_dev=1
 compare=1
 dirac=0
-tag=
+tag=getopt
 
 do_dev=1
 do_master=0

--- a/testing/test-io_refactor.sh
+++ b/testing/test-io_refactor.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-build_dev=1
+build_dev=0
 compare=1
 dirac=0
 tag=

--- a/testing/test-io_refactor.sh
+++ b/testing/test-io_refactor.sh
@@ -2,7 +2,7 @@
 build_dev=1
 compare=1
 dirac=0
-tag=getopt
+tag=
 
 do_dev=1
 do_master=0

--- a/testing/test_specex.py
+++ b/testing/test_specex.py
@@ -3,11 +3,13 @@ from specex.specex import run_specex
 import sys
 
 psffile=sys.argv[1]
-inputroot=sys.argv[2].rstrip('\n')
-
+#inputroot=sys.argv[2].rstrip('\n')
+inputroot_pre='/global/cfs/cdirs/desi/spectro/redux/blanc/preproc/20201216/00068217/'
+inputroot_exp='/global/cfs/cdirs/desi/spectro/redux/blanc/exposures/20201216/00068217/'
 first_fiber='100'
 last_fiber='104'
 
-com=['desi_psf_fit', '-a', inputroot+'/preproc-b1-00068217.fits', '--in-psf', inputroot+'/shifted-input-psf-b1-00068217.fits', '--out-psf',psffile,'--lamp-lines', 'specex-dev/code/lib/python3.8/site-packages/specex-0.7.0.dev637-py3.8-linux-x86_64.egg/specex/data/specex_linelist_desi.txt', '--first-bundle', '4', '--last-bundle', '4', '--first-fiber', first_fiber, '--last-fiber', last_fiber, '--legendre-deg-wave', '3','--fit-continuum','--debug']
+com=['desi_psf_fit', '-a', inputroot_pre+'/preproc-b1-00068217.fits', '--in-psf', inputroot_exp+'/shifted-input-psf-b1-00068217.fits', '--out-psf',psffile,'--lamp-lines', 'specex-dev/code/lib/python3.8/site-packages/specex-0.7.0.dev637-py3.8-linux-x86_64.egg/specex/data/specex_linelist_desi.txt', '--first-bundle', '4', '--last-bundle', '4', '--first-fiber', first_fiber, '--last-fiber', last_fiber, '--legendre-deg-wave', '3','--fit-continuum','--debug']
 
 run_specex(com)
+#run_specex(['desi_psf_fit','-a','foo'])


### PR DESCRIPTION
Intermediate step (rm_poptions) in sequence of branches to remove dependence on HARP and BOOST.
input_refactor --> rm_harp --> rm_unused --> matrix_refactor --> **rm_poptions**

This pull request removes all dependence on `boost::program_options` and instead uses `getopt_long()`. This version has no dependence on HARP or BOOST. 

Performance is unchanged and the code produces identical bitwise results for the file
`fit-psf-b1-00068217.fits`
with respect to master when running
`desi_compute_psf --input-image /global/cfs/cdirs/desi/spectro/redux/blanc/preproc/20201216/00068217/preproc-b1-00068217.fits --input-psf /global/cfs/cdirs/desi/spectro/redux/blanc/exposures/20201216/00068217/shifted-input-psf-b1-00068217.fits --output-psf ./fit-psf-b1-00068217.fits`

on cori.