### PR TITLE
Python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(Python_ROOT_DIR $ENV{DESICONDA})
 
-find_package (Python 3.8...3.9 REQUIRED)
-find_package (PythonInterp 3.8...3.9 REQUIRED)
-find_package (PythonLibs 3.8...3.9 REQUIRED)
+find_package (Python 3.8 REQUIRED)
+find_package (PythonInterp 3.8 REQUIRED)
+find_package (PythonLibs 3.8 REQUIRED)
 
 add_subdirectory(src/pybind11)
 pybind11_add_module(_libspecex NO_EXTRAS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(Python_ROOT_DIR $ENV{DESICONDA})
 
-find_package (Python 3.8 EXACT REQUIRED)
-find_package (PythonInterp 3.8 EXACT REQUIRED)
-find_package (PythonLibs 3.8 EXACT REQUIRED)
+find_package (Python 3.8...3.9 REQUIRED)
+find_package (PythonInterp 3.8...3.9 REQUIRED)
+find_package (PythonLibs 3.8...3.9 REQUIRED)
 
 add_subdirectory(src/pybind11)
-pybind11_add_module(_libspecex NO_EXTRAS 
+pybind11_add_module(_libspecex NO_EXTRAS
 	    src/_libspecex.cpp
 	    src/specex_psfpy.cc
 	    src/specex_pyimage.cc
@@ -92,10 +92,10 @@ target_include_directories(_libspecex
 	src
 	${MKL_INCLUDE}
 	)
-	
+
 target_link_directories(_libspecex
 	PUBLIC)
-	
+
 target_link_libraries(_libspecex PUBLIC ${BLAS_LIBRARIES})
 
 set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})

--- a/etc/specex.module
+++ b/etc/specex.module
@@ -68,7 +68,8 @@ setenv [string toupper $product] $PRODUCT_DIR
 # desiInstall script.
 
 ### prepend-path PATH $PRODUCT_DIR/bin
-prepend-path PYTHONPATH $PRODUCT_DIR/lib/python3.8/site-packages
+{needs_python}prepend-path PYTHONPATH $PRODUCT_DIR/lib/{pyversion}/site-packages
+
 #
 # Add any non-standard Module code below this point.
 #


### PR DESCRIPTION
Purpose: 
Allow specex to install with python >= 3.8. 

Description:
Fix bugs in CMakeLists.txt and etc.module that only allowed installation to proceed if python version is 3.8 and did not set the location of the installed package correctly, respectively. Minor change with no effect on run time behaviour.