### PR TITLE
support reading of psf fit parameters from input file

### DIFF
--- a/src/specex_pyoptions.h
+++ b/src/specex_pyoptions.h
@@ -121,14 +121,14 @@ namespace specex {
       use_variance_model = false;
       fit_individual_spots_position = false;
       
-      half_size_x_def = false ;
-      half_size_y_def = false;
-      gauss_hermite_deg_def = false; 
-      gauss_hermite_deg2_def = false; 
-      legendre_deg_wave_def = false; 
-      legendre_deg_x_def = false;
-      trace_deg_wave_def = false;
-      trace_deg_x_def = false; 
+      half_size_x_def = true;
+      half_size_y_def = true;
+      gauss_hermite_deg_def = true; 
+      gauss_hermite_deg2_def = true; 
+      legendre_deg_wave_def = true; 
+      legendre_deg_x_def = true;
+      trace_deg_wave_def = true;
+      trace_deg_x_def = true;
 
       return;
       

--- a/src/specex_pypsf.cc
+++ b/src/specex_pypsf.cc
@@ -58,8 +58,8 @@ void specex::PyPSF::set_psf(
     std::string pname=table_col0[i];
     params.push_back(pname);
     param_row[pname]=i;
+    param_coeff[pname] = unbls::vector_double(ncoeff_per_row);	
     for(int j=0; j < ncoeff_per_row; j++){
-      param_coeff[pname] = unbls::vector_double(ncoeff_per_row);
       param_coeff[pname][j] = table_col1[i*ncoeff_per_row+j];
     }
     param_degx[pname]=table_col2[i];


### PR DESCRIPTION
Purpose:
Allow specex to read in psf fit parameters from an input file. 

Description:
Fix bugs in `src/specex_pyoptions.h` and `src/specex_pypsf.cc`, to set boolean flags correctly for whether default psf options are being used, and to initialize the array of psf coefficient names correctly, respectively. The behaviour of specex when run as part of the spectroscopic pipeline is unchanged (details below), but the functionality to read in psf parameters is restored, and matches the behaviour of [specex 0.6.8](https://github.com/desihub/specex/tree/b4a1e1c867ca31f68c48aedcae305a611ff96046) when the input psf fit parameters are used because no psf fit options are specified. 

The behaviour of specex is only affected if no psf fit options are specified via input flags. Since the `--legendre-deg-wave` flag is [always specified](https://github.com/desihub/desispec/blob/master/py/desispec/scripts/specex.py#L176-L180) in the desispec wrapper of specex, no effect on run time behaviour when it is called in the spectroscopic pipeilne with [`desispec/bin/desi_proc`](https://github.com/desihub/desispec/blob/master/bin/desi_proc) --> [`desispec/py/scripts/proc.py`](https://github.com/desihub/desispec/blob/master/py/desispec/scripts/proc.py#L426)  --> [`desispec/scripts/specex.py`](https://github.com/desihub/desispec/blob/master/py/desispec/scripts/specex.py#L190) --> [`specex/py/specex/specex.py`](https://github.com/desihub/specex/blob/master/py/specex/specex.py#L5) or with [`desi_compute_psf`](https://github.com/desihub/desispec/blob/master/bin/desi_compute_psf)/[`desi_compute_psf_mpi`](https://github.com/desihub/desispec/blob/master/bin/desi_compute_psf_mpi) --> [`specex/py/specex/specex.py`](https://github.com/desihub/specex/blob/master/py/specex/specex.py#L5), directly.  

Pleaes approve and merge. 