### PR TITLE
Fixes silent PSF fit fatal error

### DIFF
--- a/src/specex_message.h
+++ b/src/specex_message.h
@@ -22,6 +22,6 @@ void specex_error(const std::string& mess);
 #define SPECEX_DEBUG(mess) {std::stringstream ss; ss << mess; specex_debug(ss.str()); }
 #define SPECEX_INFO(mess) {std::stringstream ss; ss << mess; specex_info(ss.str()); }
 #define SPECEX_WARNING(mess) {std::stringstream ss; ss << mess; specex_warning(ss.str()); }
-#define SPECEX_ERROR(mess) {std::stringstream ss; ss << mess; if(specex_dump_core()) {ss << " (at line " << __LINE__ << " of file " << __FILE__ << ")"; specex_error(ss.str());}}
+#define SPECEX_ERROR(mess) {std::stringstream ss; ss << mess << " (at line " << __LINE__ << " of file " << __FILE__ << ")"; if(specex_dump_core()) {specex_error(ss.str());} else {throw std::runtime_error(ss.str());} }
 
 #endif


### PR DESCRIPTION
Fixes #53 -- Silent PSF fit fatal error by throwing a `std::runtime_error() `exception when `SPECEX_ERROR()` is called. 

Verified this solution by hardcoding a call to `SPECEX_ERROR` when a specific camera string is in the arc preproc exposure image file name and verifying that the PSF for that camera is not written, an error is logged, the rest of the PSFs are written, and the job proceeds normally. 

Please verify this is the expected behaviour and merge. 