### PR TITLE
Use return value to signal a fatal error

### DIFF
--- a/py/specex/specex.py
+++ b/py/specex/specex.py
@@ -32,9 +32,9 @@ def run_specex(com):
     pymg = read_preproc(opts) 
     
     # fit psf 
-    pyft.fit_psf(opts,pyio,pypr,pymg,pyps) 
+    retval = pyft.fit_psf(opts,pyio,pypr,pymg,pyps) 
     
     # write psf 
     write_psf(pyps,opts,pyio)        
 
-    return 0
+    return retval


### PR DESCRIPTION
Modifies function `run_specex` to return the same value as `fit_psf` signaling fatal errors so that calling functions can handle them appropriately. 

Currently, any call to `SPECEX_ERROR` during execution of `fit_psf` results in an exception that is caught in `fit_psf`, resulting in a non-zero return value of `EXIT_FAILURE`, but since `run_specex` does not use the return value, this information is lost.

Testing at NERSC with arc exposure 103082 (in which `SPECEX_ERROR` calls currently occur for camera z6) using the command
```
srun -N 1 -n 41 -c 1 desi_proc --traceshift --cameras z67 -n 20211005 -e 103082
```
with this branch leads to the expected behaviour that the PSF for z6 is not written (while the PSF for z7 is) the error is reported, and the processes continue as normal. With the master branch, PSFs for both z6 and z7 are written, with erroneous results (e.g., inconsistent values of HSIZEX between bundles) in the z6 PSF.

This fixes #53 and subsequent silent PSF fitting failures not fixed by #54. See #53 for additional details. Please review and merge if appropriate. 