### PR TITLE
Use MKL BLAS by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ pybind11_add_module(_libspecex NO_EXTRAS
 set(BLA_VENDOR Intel10_64lp)
 find_package (BLAS)
 find_package (LAPACK)
-if(BLAS_FOUND AND (DEFINED ENV{DESI_SPX_MKL}))
+if(BLAS_FOUND)
 
 	# this also means MKL with BLAS libraries were found
 	# now see if MKL include file can be found as well
@@ -72,7 +72,6 @@ if(NOT MKL_FOUND)
 
 	# if MKL BLAS and mkl.h not both found, look for OpenBLAS/LAPACK
 	set(BLAS_FOUND FALSE)
-	set(BLA_VENDOR OpenBLAS)
 	find_package (BLAS)
 	find_package (LAPACK)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 if(NOT MKL_FOUND)
 
-	# if MKL BLAS and mkl.h not both found, look for OpenBLAS/LAPACK
+	# if MKL BLAS and mkl.h not both found, use available BLAS/LAPACK
 	set(BLAS_FOUND FALSE)
 	find_package (BLAS)
 	find_package (LAPACK)


### PR DESCRIPTION
Use MKL BLAS by default. This is the desired behaviour on cori with the latest version of desiconda. 

Please review and merge if appropriate. 