### PR TITLE
Report failure when traces for good fibers overlap

### DIFF
--- a/py/specex/qa.py
+++ b/py/specex/qa.py
@@ -2,11 +2,27 @@ from desispec.io.xytraceset import read_xytraceset
 from desiutil.log import get_logger
 import numpy as np
 
-def psf_qa(opts):
+def trace_psf_qa(psf_filename, broken_fiber_list):
+    """
+    QA PSF by reporting overlapping fiber traces.
+
+    Args:
+        psf_filename: string, input PSF file
+        broken_fiber_list: string, comma separated list of broken fibers
+
+    Returns:
+        failcount: int, number of neighboring fibers with overlapping traces
+                   where neither is on in broken_fiber_list
+    """
+
     log = get_logger()
 
-    brokenfibers = list(map(int,opts.broken_fibers_string.split(",")))
-    fibertraces = read_xytraceset(opts.output_fits_filename)
+    if len(broken_fiber_list) > 0:
+        brokenfibers = list(map(int,broken_fiber_list.split(",")))
+    else:
+        brokenfibers = []
+
+    fibertraces = read_xytraceset(psf_filename)
     ww = np.arange(fibertraces.wavemin, fibertraces.wavemax)
     
     failcount=0
@@ -14,11 +30,23 @@ def psf_qa(opts):
         correct = np.all(fibertraces.x_vs_wave(fiber+1, ww) > fibertraces.x_vs_wave(fiber, ww))
         if not correct:
             if fiber in brokenfibers:
-                log.warning("broken fiber {} overlaps {} in {}".format(fiber, fiber+1, opts.output_fits_filename))
+                log.warning("broken fiber {} overlaps {} in {}".format(fiber, fiber+1, psf_filename))
             if fiber+1 in brokenfibers:
-                log.warning("broken fiber {} overlaps {} in {}".format(fiber+1, fiber, opts.output_fits_filename))
+                log.warning("broken fiber {} overlaps {} in {}".format(fiber+1, fiber, psf_filename))
             if fiber not in brokenfibers and fiber+1 not in brokenfibers:
-                log.error("overlapping traces for fibers {} and {} in {}".format(fiber, fiber+1, opts.output_fits_filename))
+                log.error("overlapping traces for fibers {} and {} in {}".format(fiber, fiber+1, psf_filename))
                 failcount += 1
+
+    return failcount
+
+def specex_psf_qa(opts):
+
+    # trace QA
+    psf_filename = opts.output_fits_filename
+    broken_fiber_list = opts.broken_fibers_string
+
+    failcount = 0
+
+    failcount += trace_psf_qa(psf_filename, broken_fiber_list)
 
     return failcount

--- a/py/specex/qa.py
+++ b/py/specex/qa.py
@@ -1,0 +1,24 @@
+from desispec.io.xytraceset import read_xytraceset
+from desiutil.log import get_logger
+import numpy as np
+
+def psf_qa(opts):
+    log = get_logger()
+
+    brokenfibers = list(map(int,opts.broken_fibers_string.split(",")))
+    fibertraces = read_xytraceset(opts.output_fits_filename)
+    ww = np.arange(fibertraces.wavemin, fibertraces.wavemax)
+    
+    failcount=0
+    for fiber in range(0,fibertraces.nspec-1):
+        correct = np.all(fibertraces.x_vs_wave(fiber+1, ww) > fibertraces.x_vs_wave(fiber, ww))
+        if not correct:
+            if fiber in brokenfibers:
+                log.warning("broken fiber {} overlaps {} in {}".format(fiber, fiber+1, opts.output_fits_filename))
+            if fiber+1 in brokenfibers:
+                log.warning("broken fiber {} overlaps {} in {}".format(fiber+1, fiber, opts.output_fits_filename))
+            if fiber not in brokenfibers and fiber+1 not in brokenfibers:
+                log.error("overlapping traces for fibers {} and {} in {}".format(fiber, fiber+1, opts.output_fits_filename))
+                failcount += 1
+
+    return failcount

--- a/py/specex/specex.py
+++ b/py/specex/specex.py
@@ -1,6 +1,7 @@
 import numpy as np
 from specex._libspecex import (PyOptions,PyIO,PyPrior,PyPSF,PyFitting,VectorString)
 from specex.io import (read_preproc, write_psf, read_psf)
+from specex.qa import (psf_qa)
 
 def run_specex(com):
 
@@ -37,5 +38,8 @@ def run_specex(com):
     
     # write psf 
     write_psf(pyps,opts,pyio)        
+
+    # do QA on psf
+    retval += psf_qa(opts)
 
     return retval

--- a/py/specex/specex.py
+++ b/py/specex/specex.py
@@ -1,7 +1,7 @@
 import numpy as np
 from specex._libspecex import (PyOptions,PyIO,PyPrior,PyPSF,PyFitting,VectorString)
 from specex.io import (read_preproc, write_psf, read_psf)
-from specex.qa import (psf_qa)
+from specex.qa import (specex_psf_qa)
 
 def run_specex(com):
 
@@ -39,7 +39,7 @@ def run_specex(com):
     # write psf 
     write_psf(pyps,opts,pyio)        
 
-    # do QA on psf
-    retval += psf_qa(opts)
+    # do QA
+    retval += specex_psf_qa(opts)
 
     return retval

--- a/src/_libspecex.cpp
+++ b/src/_libspecex.cpp
@@ -202,6 +202,7 @@ PYBIND11_MODULE(_libspecex, m) {
         .def_readwrite("output_fits_filename", &spx::PyOptions::output_fits_filename)
         .def_readwrite("trace_deg_x",          &spx::PyOptions::trace_deg_x)
         .def_readwrite("trace_deg_wave",       &spx::PyOptions::trace_deg_wave)
+        .def_readwrite("broken_fibers_string", &spx::PyOptions::broken_fibers_string)
 
         .def("parse", [](spx::PyOptions &self, std::vector<std::string>& args){
 	    std::vector<char *> cstrs;


### PR DESCRIPTION
Modifies `run_specex` to return a non-zero value and print an error message to the log if the x (the direction perpendicular to wavelength on the ccd) coordinate of the trace for any given fiber not in the list of broken fibers passed to specex is not always greater than the preceding fiber and less than the following fiber. If the fiber is in the list of broken fibers, then only a warning is printed.

This indirectly addresses the issue in #69 since it would have prevented the erroneous traces from bad calibration data taken for 20220923 from being included in the default PSF that caused the subsequent arc failures.

I have tested this by processing the arcs from 20220923 with `desi_run_night`. Using specex from the main branch, processing for exposure 144026 completes successfully and outpus a PSF with unphysical overlapping trace fits, while on this branch the job fails and reports the bad fits in the log:
```
% grep overlapping /global/cfs/cdirs/desi/users/malvarez/spectro/redux/specex-offlamps/trace-overlap-20220923/run/scripts/night/20220923/arc-20220923-00144026-a0123456789-11560964.log
ERROR:qa.py:21:psf_qa: overlapping traces for fibers 486 and 487 in /global/cfs/cdirs/desi/users/malvarez/spectro/redux/specex-offlamps/trace-overlap-20220923/exposures/20220923/00144026/fit-psf-z7-00144026_19.fits
ERROR:qa.py:21:psf_qa: overlapping traces for fibers 486 and 487 in /global/cfs/cdirs/desi/users/malvarez/spectro/redux/specex-offlamps/trace-overlap-20220923/exposures/20220923/00144026/fit-psf-b7-00144026_19.fits
ERROR:qa.py:21:psf_qa: overlapping traces for fibers 487 and 488 in /global/cfs/cdirs/desi/users/malvarez/spectro/redux/specex-offlamps/trace-overlap-20220923/exposures/20220923/00144026/fit-psf-b7-00144026_19.fits
ERROR:qa.py:21:psf_qa: overlapping traces for fibers 170 and 171 in /global/cfs/cdirs/desi/users/malvarez/spectro/redux/specex-offlamps/trace-overlap-20220923/exposures/20220923/00144026/fit-psf-b4-00144026_06.fits
ERROR:qa.py:21:psf_qa: overlapping traces for fibers 276 and 277 in /global/cfs/cdirs/desi/users/malvarez/spectro/redux/specex-offlamps/trace-overlap-20220923/exposures/20220923/00144026/fit-psf-b4-00144026_11.fits
```

Issues that can cause these failures should result in flagging the entire exposure (as in the case for 20220923 where arc lamps were not being exposed correctly) and/or affected fibers as bad (due to being broken or having too low a throughput), and this new failure mode for specex provides an additional safeguard against  unphysical calibration data being propagated downstream.

@sbailey @julienguy please have a look.