### PR TITLE
include cstdint to support gcc/13 at NERSC

### DIFF
--- a/src/_libspecex.cpp
+++ b/src/_libspecex.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <sstream>
+#include <cstdint>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>


### PR DESCRIPTION
This PR adds `#include <cstdint>` which is now needed when using gcc/13 at NERSC to avoid compile errors like
```
/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/specex/main/src/pybind11/include/pybind11/pybind11.h:294:28: error: ‘uint16_t’ is not a member of ‘std’; did you mean ‘wint_t’?
  294 |         rec->nargs = (std::uint16_t) args;
      |                            ^~~~~~~~
      |                            wint_t
```

It is unclear what changed for why this is now needed (I have a separate ticket open with NERSC about that), but it also appears to be harmless for gcc/12.