### PR TITLE
Changed so that missing bundles return a -1 to STATUS and failed fits return a 4 to STATUS

### DIFF
--- a/src/specex_psf.h
+++ b/src/specex_psf.h
@@ -61,7 +61,7 @@ namespace specex {
     int ndata;
     int ndata_in_core;
     int nparams;
-    int fit_status; // -1=no fit performed 0=ok 1=cholesky error 2=no convergence 3=nan in fit
+    int fit_status; // -1=no fit performed/missing 0=ok 1=cholesky error 2=no convergence 3=nan in fit 4=failed fit
     int nspots_in_fit;
 
 #define CONTINUUM

--- a/src/specex_psf.h
+++ b/src/specex_psf.h
@@ -73,7 +73,7 @@ namespace specex {
 
   PSF_Params() : 
     bundle_id(0), fiber_min(0), fiber_max(0), 
-      chi2(0),ndata(0),fit_status(-1), nspots_in_fit(0)
+      chi2(0),ndata(0),fit_status(4), nspots_in_fit(0)
 #ifdef CONTINUUM
 , continuum_sigma_x(1)
 #endif


### PR DESCRIPTION
This changes the initialization of the `fit_status` to 4. This should separate it out so that bundles that are missing now have a status of -1 while bundles that failed to fit have a status of 4.

This is to help solve this issue in desispec: https://github.com/desihub/desispec/issues/2701